### PR TITLE
trace: frame pointer unwinding for taskdumps + lazy symbolization API

### DIFF
--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -3,7 +3,7 @@
 //! See [`Handle::dump`][crate::runtime::Handle::dump].
 
 use crate::task::Id;
-use std::{fmt, future::Future, path::Path};
+use std::{ffi::c_void, fmt, future::Future, path::Path};
 
 pub use crate::runtime::task::trace::Root;
 
@@ -169,18 +169,14 @@ impl Trace {
     /// Returns the raw (unresolved) instruction pointers for each linear
     /// backtrace in this trace, without performing any symbolization.
     ///
-    /// Each inner `Vec<u64>` corresponds to one leaf future's poll backtrace,
+    /// Each inner slice corresponds to one leaf future's poll backtrace,
     /// ordered from innermost frame (closest to the leaf) outward. The
     /// addresses are suitable for offline symbolization (e.g. with `addr2line`
     /// or `blazesym`) after adjusting for the process's load address.
     ///
     /// This method never acquires any lock and performs no I/O.
-    pub fn raw_backtraces(&self) -> Vec<Vec<u64>> {
-        self.inner
-            .backtraces()
-            .iter()
-            .map(|bt| bt.iter().map(|&addr| addr as u64).collect())
-            .collect()
+    pub fn raw_backtraces(&self) -> impl Iterator<Item = &[*mut c_void]> {
+        self.inner.backtraces().iter().map(|bt| bt.as_slice())
     }
 
     /// Resolve and return a list of backtraces that are involved in polls in this trace.

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -57,18 +57,6 @@ pub struct BacktraceSymbol {
 }
 
 impl BacktraceSymbol {
-    pub(crate) fn from_backtrace_symbol(sym: &backtrace::BacktraceSymbol) -> Self {
-        let name = sym.name();
-        Self {
-            name: name.as_ref().map(|name| name.as_bytes().into()),
-            name_demangled: name.map(|name| format!("{name}").into()),
-            addr: sym.addr().map(Address),
-            filename: sym.filename().map(From::from),
-            lineno: sym.lineno(),
-            colno: sym.colno(),
-        }
-    }
-
     /// Return the raw name of the symbol.
     pub fn name_raw(&self) -> Option<&[u8]> {
         self.name.as_deref()
@@ -116,18 +104,6 @@ pub struct BacktraceFrame {
 }
 
 impl BacktraceFrame {
-    pub(crate) fn from_resolved_backtrace_frame(frame: &backtrace::BacktraceFrame) -> Self {
-        Self {
-            ip: Address(frame.ip()),
-            symbol_address: Address(frame.symbol_address()),
-            symbols: frame
-                .symbols()
-                .iter()
-                .map(BacktraceSymbol::from_backtrace_symbol)
-                .collect(),
-        }
-    }
-
     /// Return the instruction pointer of this frame.
     ///
     /// See the ABI docs for your platform for the exact meaning.
@@ -190,6 +166,23 @@ pub struct Trace {
 }
 
 impl Trace {
+    /// Returns the raw (unresolved) instruction pointers for each linear
+    /// backtrace in this trace, without performing any symbolization.
+    ///
+    /// Each inner `Vec<u64>` corresponds to one leaf future's poll backtrace,
+    /// ordered from innermost frame (closest to the leaf) outward. The
+    /// addresses are suitable for offline symbolization (e.g. with `addr2line`
+    /// or `blazesym`) after adjusting for the process's load address.
+    ///
+    /// This method never acquires any lock and performs no I/O.
+    pub fn raw_backtraces(&self) -> Vec<Vec<u64>> {
+        self.inner
+            .backtraces()
+            .iter()
+            .map(|bt| bt.iter().map(|&addr| addr as u64).collect())
+            .collect()
+    }
+
     /// Resolve and return a list of backtraces that are involved in polls in this trace.
     ///
     /// The exact backtraces included here are unstable and might change in the future,
@@ -203,16 +196,29 @@ impl Trace {
         self.inner
             .backtraces()
             .iter()
-            .map(|backtrace| {
-                let mut backtrace = backtrace::Backtrace::from(backtrace.clone());
-                backtrace.resolve();
-                Backtrace {
-                    frames: backtrace
-                        .frames()
-                        .iter()
-                        .map(BacktraceFrame::from_resolved_backtrace_frame)
-                        .collect(),
+            .map(|raw_bt| {
+                let mut frames: Vec<BacktraceFrame> = Vec::new();
+                for &addr in raw_bt {
+                    let mut symbols: Vec<BacktraceSymbol> = Vec::new();
+                    backtrace::resolve(addr as *mut _, |sym| {
+                        symbols.push(BacktraceSymbol {
+                            name: sym.name().map(|n| n.as_bytes().into()),
+                            name_demangled: sym.name().map(|n| format!("{n}").into()),
+                            addr: sym.addr().map(Address),
+                            filename: sym.filename().map(From::from),
+                            lineno: sym.lineno(),
+                            colno: sym.colno(),
+                        });
+                    });
+                    frames.push(BacktraceFrame {
+                        ip: Address(addr as *mut _),
+                        symbol_address: Address(
+                            symbols.first().and_then(|s| s.addr).map_or(addr, |a| a.0)
+                        ),
+                        symbols: symbols.into_boxed_slice(),
+                    });
                 }
+                Backtrace { frames: frames.into_boxed_slice() }
             })
             .collect()
     }

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -3,9 +3,9 @@
 //! See [`Handle::dump`][crate::runtime::Handle::dump].
 
 use crate::task::Id;
-use std::{ffi::c_void, fmt, future::Future, path::Path};
+use std::{fmt, future::Future, path::Path};
 
-pub use crate::runtime::task::trace::Root;
+pub use crate::runtime::task::trace::{FrameAddr, Root};
 
 /// A snapshot of a runtime's state.
 ///
@@ -175,7 +175,7 @@ impl Trace {
     /// or `blazesym`) after adjusting for the process's load address.
     ///
     /// This method never acquires any lock and performs no I/O.
-    pub fn raw_backtraces(&self) -> impl Iterator<Item = &[*mut c_void]> {
+    pub fn raw_backtraces(&self) -> impl Iterator<Item = &[FrameAddr]> {
         self.inner.backtraces().iter().map(|bt| bt.as_slice())
     }
 
@@ -196,7 +196,7 @@ impl Trace {
                 let mut frames: Vec<BacktraceFrame> = Vec::new();
                 for &addr in raw_bt {
                     let mut symbols: Vec<BacktraceSymbol> = Vec::new();
-                    backtrace::resolve(addr as *mut _, |sym| {
+                    backtrace::resolve(addr.addr(), |sym| {
                         symbols.push(BacktraceSymbol {
                             name: sym.name().map(|n| n.as_bytes().into()),
                             name_demangled: sym.name().map(|n| format!("{n}").into()),
@@ -207,9 +207,9 @@ impl Trace {
                         });
                     });
                     frames.push(BacktraceFrame {
-                        ip: Address(addr as *mut _),
+                        ip: Address(addr.addr()),
                         symbol_address: Address(
-                            symbols.first().and_then(|s| s.addr).map_or(addr, |a| a.0)
+                            symbols.first().and_then(|s| s.addr).map_or(addr.addr(), |a| a.0)
                         ),
                         symbols: symbols.into_boxed_slice(),
                     });

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -228,6 +228,13 @@ impl Trace {
     /// Also see [`Handle::dump`] for more documentation about dumps, but unlike [`Handle::dump`], this function
     /// should not be much slower than calling `f` directly.
     ///
+    /// Uses frame pointer unwinding to collect stack traces. The binary must
+    /// be compiled with `-C force-frame-pointers=yes` for correct results;
+    /// without frame pointers the trace will be empty.
+    ///
+    /// Only supported on x86_64 and aarch64. On other architectures this
+    /// produces empty traces.
+    ///
     /// Due to the way tracing is implemented, Tokio leaf futures will usually, instead of doing their
     /// actual work, do the equivalent of a `yield_now` (returning a `Poll::Pending` and scheduling the
     /// current context for execution), which means forward progress will probably not happen unless
@@ -270,24 +277,6 @@ impl Trace {
         F: FnOnce() -> R,
     {
         let (res, trace) = super::task::trace::Trace::capture(f);
-        (res, Trace { inner: trace })
-    }
-
-    /// Like [`capture`](Self::capture), but uses frame pointer unwinding
-    /// instead of `backtrace::trace`.
-    ///
-    /// This avoids the global lock in backtrace-rs, making it suitable for
-    /// use on every poll in tracing/instrumentation libraries. However, the
-    /// binary **must** be compiled with `-C force-frame-pointers=yes` or the
-    /// trace will be empty.
-    ///
-    /// Only supported on x86_64 and aarch64. On other architectures this
-    /// produces empty traces.
-    pub fn capture_fp<F, R>(f: F) -> (R, Trace)
-    where
-        F: FnOnce() -> R,
-    {
-        let (res, trace) = super::task::trace::Trace::capture_fp(f);
         (res, Trace { inner: trace })
     }
 

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -273,6 +273,24 @@ impl Trace {
         (res, Trace { inner: trace })
     }
 
+    /// Like [`capture`](Self::capture), but uses frame pointer unwinding
+    /// instead of `backtrace::trace`.
+    ///
+    /// This avoids the global lock in backtrace-rs, making it suitable for
+    /// use on every poll in tracing/instrumentation libraries. However, the
+    /// binary **must** be compiled with `-C force-frame-pointers=yes` or the
+    /// trace will be empty.
+    ///
+    /// Only supported on x86_64 and aarch64. On other architectures this
+    /// produces empty traces.
+    pub fn capture_fp<F, R>(f: F) -> (R, Trace)
+    where
+        F: FnOnce() -> R,
+    {
+        let (res, trace) = super::task::trace::Trace::capture_fp(f);
+        (res, Trace { inner: trace })
+    }
+
     /// Create a root for stack traces captured using [`Trace::capture`]. Stack frames above
     /// the root will not be captured.
     ///

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -553,6 +553,17 @@ cfg_taskdump! {
         /// split-debuginfo = "off"
         /// ```
         ///
+        /// ## Frame Pointers Must Be Enabled
+        ///
+        /// Task dumps rely on frame pointer unwinding to capture stack traces.
+        /// The application must be compiled with frame pointers enabled, or
+        /// traces will be empty. Add the following to `.cargo/config.toml`:
+        ///
+        /// ```text
+        /// [build]
+        /// rustflags = ["-C", "force-frame-pointers=yes", "--cfg", "tokio_unstable"]
+        /// ```
+        ///
         /// ## Unstable Features
         ///
         /// This functionality is **unstable**, and requires both the
@@ -561,14 +572,14 @@ cfg_taskdump! {
         /// You can do this by setting the `RUSTFLAGS` environment variable
         /// before invoking `cargo`; e.g.:
         /// ```bash
-        /// RUSTFLAGS="--cfg tokio_unstable" cargo run --example dump
+        /// RUSTFLAGS="--cfg tokio_unstable -C force-frame-pointers=yes" cargo run --example dump
         /// ```
         ///
         /// Or by [configuring][cargo-config] `rustflags` in
         /// `.cargo/config.toml`:
         /// ```text
         /// [build]
-        /// rustflags = ["--cfg", "tokio_unstable"]
+        /// rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]
         /// ```
         ///
         /// [cargo-config]:

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -184,22 +184,14 @@ pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
                     // We collect raw return addresses here and defer
                     // symbolization to display time (in tree.rs), matching the
                     // "new_unresolved" pattern but without any lock acquisition.
-                    //
-                    // The sentinel comparisons use the return address directly.
-                    // Because a return address points *inside* the caller (just
-                    // past the call instruction), we check whether each address
-                    // falls within the function's body rather than comparing
-                    // against its exact start address.
-                    #[cfg(target_arch = "x86_64")]
+                    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
                     {
                         let mut fp: *const usize;
+                        #[cfg(target_arch = "x86_64")]
                         std::arch::asm!("mov {}, rbp", out(reg) fp);
+                        #[cfg(target_arch = "aarch64")]
+                        std::arch::asm!("mov {}, x29", out(reg) fp);
 
-                        // Resolve sentinel bounds.  trace_leaf_bounds() is
-                        // cached after the first call; resolve_root_bounds()
-                        // calls backtrace::resolve once per dump (acceptable:
-                        // dumps are rare and the lock is not held during the
-                        // walk itself).
                         let leaf_bounds = trace_leaf_bounds();
                         let root_bounds = resolve_root_bounds(active_frame.inner_addr);
 
@@ -233,10 +225,8 @@ pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
                         }
                     }
 
-                    // On non-x86_64 targets fall back to the backtrace crate.
-                    // (frame-pointer unwinding on other arches can be added
-                    // incrementally.)
-                    #[cfg(not(target_arch = "x86_64"))]
+                    // On other targets fall back to the backtrace crate.
+                    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
                     {
                         let mut above_leaf = false;
                         backtrace::trace(|frame| {
@@ -322,7 +312,7 @@ impl FunctionBounds {
 ///
 /// The `trace_leaf` function is concrete (not generic), so its bounds are
 /// stable for the lifetime of the process.
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn trace_leaf_bounds() -> FunctionBounds {
     use std::sync::OnceLock;
     static BOUNDS: OnceLock<FunctionBounds> = OnceLock::new();
@@ -337,7 +327,7 @@ fn trace_leaf_bounds() -> FunctionBounds {
 /// is no convenient place to store per-type statics.  The lock is only held
 /// during the *first* dump that encounters a given `T`; afterwards the OS
 /// symbol-resolution cache makes repeated calls cheap.
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn resolve_root_bounds(inner_addr: *const c_void) -> FunctionBounds {
     FunctionBounds::resolve(inner_addr)
 }

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -23,7 +23,7 @@ use super::{Notified, OwnedTasks, Schedule};
 
 /// A raw backtrace captured via frame pointer unwinding.
 /// Each element is a return address collected while walking the call stack.
-type Backtrace = Vec<*mut c_void>;
+type Backtrace = Vec<FrameAddr>;
 type SymbolTrace = Vec<Symbol>;
 
 /// The ambient backtracing context.
@@ -48,6 +48,27 @@ struct Frame {
 ///
 /// Traces are captured with [`Trace::capture`], rooted with [`Trace::root`]
 /// and leaved with [`trace_leaf`].
+/// A raw instruction pointer captured during stack unwinding.
+///
+/// This is a code address (not a pointer to data) suitable for passing to
+/// `backtrace::resolve` or offline symbolization tools like `addr2line`.
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
+pub struct FrameAddr(*mut c_void);
+
+// SAFETY: The wrapped pointer is a code address (instruction pointer),
+// not a pointer to owned heap data. Safe to send/share across threads.
+unsafe impl Send for FrameAddr {}
+unsafe impl Sync for FrameAddr {}
+
+impl FrameAddr {
+    /// Returns the raw instruction pointer.
+    #[inline]
+    pub fn addr(self) -> *mut c_void {
+        self.0
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum TraceMode {
     /// Use `backtrace::trace` (always works, takes global lock).
@@ -67,12 +88,6 @@ pub(crate) struct Trace {
     backtraces: Vec<Backtrace>,
     mode: TraceMode,
 }
-
-// SAFETY: `Backtrace` is `Vec<*mut c_void>` where the pointers are code
-// addresses (instruction pointers), not pointers to owned heap data.
-// It is safe to send these across threads.
-unsafe impl Send for Trace {}
-unsafe impl Sync for Trace {}
 
 pin_project_lite::pin_project! {
     #[derive(Debug, Clone)]
@@ -283,7 +298,7 @@ fn trace_leaf_fp(frames: &mut Backtrace, active_frame: &Frame) {
             let below_root = !root_bounds.contains(ret_addr);
 
             if above_leaf && below_root {
-                frames.push(ret_addr);
+                frames.push(FrameAddr(ret_addr));
             }
 
             if !above_leaf && leaf_bounds.contains(ret_addr) {
@@ -315,7 +330,7 @@ fn trace_leaf_backtrace(frames: &mut Backtrace, active_frame: &Frame) {
     backtrace::trace(|frame| {
         let below_root = !ptr::eq(frame.symbol_address(), active_frame.inner_addr);
         if above_leaf && below_root {
-            frames.push(frame.ip());
+            frames.push(FrameAddr(frame.ip()));
         }
         if ptr::eq(frame.symbol_address(), trace_leaf as *const _) {
             above_leaf = true;

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -48,11 +48,24 @@ struct Frame {
 ///
 /// Traces are captured with [`Trace::capture`], rooted with [`Trace::root`]
 /// and leaved with [`trace_leaf`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TraceMode {
+    /// Use `backtrace::trace` (always works, takes global lock).
+    Backtrace,
+    /// Use frame pointer unwinding (no lock, requires `-C force-frame-pointers=yes`).
+    FramePointer,
+}
+
+/// An tree execution trace.
+///
+/// Traces are captured with [`Trace::capture`], rooted with [`Trace::root`]
+/// and leaved with [`trace_leaf`].
 #[derive(Clone, Debug)]
 pub(crate) struct Trace {
     // The linear backtraces that comprise this trace. These linear traces can
     // be re-knitted into a tree.
     backtraces: Vec<Backtrace>,
+    mode: TraceMode,
 }
 
 // SAFETY: `Backtrace` is `Vec<*mut c_void>` where the pointers are code
@@ -134,7 +147,30 @@ impl Trace {
     where
         F: FnOnce() -> R,
     {
-        let collector = Trace { backtraces: vec![] };
+        Self::capture_with_mode(f, TraceMode::Backtrace)
+    }
+
+    /// Like [`capture`](Self::capture), but uses frame pointer unwinding
+    /// instead of `backtrace::trace`. This avoids the global lock in
+    /// backtrace-rs, but requires the binary to be compiled with
+    /// `-C force-frame-pointers=yes`.
+    #[inline(never)]
+    pub(crate) fn capture_fp<F, R>(f: F) -> (R, Trace)
+    where
+        F: FnOnce() -> R,
+    {
+        Self::capture_with_mode(f, TraceMode::FramePointer)
+    }
+
+    #[inline(never)]
+    fn capture_with_mode<F, R>(f: F, mode: TraceMode) -> (R, Trace)
+    where
+        F: FnOnce() -> R,
+    {
+        let collector = Trace {
+            backtraces: vec![],
+            mode,
+        };
 
         let previous = Context::with_current_collector(|current| current.replace(Some(collector)));
 
@@ -177,69 +213,13 @@ pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
                 if let Some(active_frame) = context_cell.active_frame.get() {
                     let active_frame = active_frame.as_ref();
 
-                    // Walk the call stack using frame pointers instead of
-                    // backtrace::trace. This avoids the global lock in
-                    // backtrace-rs and is significantly faster on hot paths.
-                    //
-                    // We collect raw return addresses here and defer
-                    // symbolization to display time (in tree.rs), matching the
-                    // "new_unresolved" pattern but without any lock acquisition.
-                    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-                    {
-                        let mut fp: *const usize;
-                        #[cfg(target_arch = "x86_64")]
-                        std::arch::asm!("mov {}, rbp", out(reg) fp);
-                        #[cfg(target_arch = "aarch64")]
-                        std::arch::asm!("mov {}, x29", out(reg) fp);
-
-                        let leaf_bounds = trace_leaf_bounds();
-                        let root_bounds = resolve_root_bounds(active_frame.inner_addr);
-
-                        let mut above_leaf = false;
-
-                        while !fp.is_null() && fp.is_aligned() {
-                            let ret_addr = *fp.add(1) as *mut c_void;
-                            if ret_addr.is_null() {
-                                break;
-                            }
-
-                            let below_root = !root_bounds.contains(ret_addr);
-
-                            if above_leaf && below_root {
-                                frames.push(ret_addr);
-                            }
-
-                            if !above_leaf && leaf_bounds.contains(ret_addr) {
-                                above_leaf = true;
-                            }
-
-                            if !below_root {
-                                break;
-                            }
-
-                            let next = *fp as *const usize;
-                            if next <= fp {
-                                break;
-                            }
-                            fp = next;
+                    match collector.mode {
+                        TraceMode::FramePointer => {
+                            trace_leaf_fp(&mut frames, active_frame);
                         }
-                    }
-
-                    // On other targets fall back to the backtrace crate.
-                    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-                    {
-                        let mut above_leaf = false;
-                        backtrace::trace(|frame| {
-                            let below_root =
-                                !ptr::eq(frame.symbol_address(), active_frame.inner_addr);
-                            if above_leaf && below_root {
-                                frames.push(frame.ip());
-                            }
-                            if ptr::eq(frame.symbol_address(), trace_leaf as *const _) {
-                                above_leaf = true;
-                            }
-                            below_root
-                        });
+                        TraceMode::Backtrace => {
+                            trace_leaf_backtrace(&mut frames, active_frame);
+                        }
                     }
                 }
 
@@ -276,6 +256,72 @@ impl fmt::Display for Trace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Tree::from_trace(self.clone()).fmt(f)
     }
+}
+
+/// Walk the stack using frame pointers. Only available on x86_64 and aarch64.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[inline(never)]
+fn trace_leaf_fp(frames: &mut Backtrace, active_frame: &Frame) {
+    unsafe {
+        let mut fp: *const usize;
+        #[cfg(target_arch = "x86_64")]
+        std::arch::asm!("mov {}, rbp", out(reg) fp);
+        #[cfg(target_arch = "aarch64")]
+        std::arch::asm!("mov {}, x29", out(reg) fp);
+
+        let leaf_bounds = trace_leaf_bounds();
+        let root_bounds = resolve_root_bounds(active_frame.inner_addr);
+
+        let mut above_leaf = false;
+
+        while !fp.is_null() && fp.is_aligned() {
+            let ret_addr = *fp.add(1) as *mut c_void;
+            if ret_addr.is_null() {
+                break;
+            }
+
+            let below_root = !root_bounds.contains(ret_addr);
+
+            if above_leaf && below_root {
+                frames.push(ret_addr);
+            }
+
+            if !above_leaf && leaf_bounds.contains(ret_addr) {
+                above_leaf = true;
+            }
+
+            if !below_root {
+                break;
+            }
+
+            let next = *fp as *const usize;
+            if next <= fp {
+                break;
+            }
+            fp = next;
+        }
+    }
+}
+
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+fn trace_leaf_fp(_frames: &mut Backtrace, _active_frame: &Frame) {
+    // Frame pointer unwinding is not supported on this architecture.
+}
+
+/// Walk the stack using `backtrace::trace`. Works on all platforms.
+#[inline(never)]
+fn trace_leaf_backtrace(frames: &mut Backtrace, active_frame: &Frame) {
+    let mut above_leaf = false;
+    backtrace::trace(|frame| {
+        let below_root = !ptr::eq(frame.symbol_address(), active_frame.inner_addr);
+        if above_leaf && below_root {
+            frames.push(frame.ip());
+        }
+        if ptr::eq(frame.symbol_address(), trace_leaf as *const _) {
+            above_leaf = true;
+        }
+        below_root
+    });
 }
 
 /// The start and (exclusive) end address of a function's machine code, as

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -277,6 +277,24 @@ impl fmt::Display for Trace {
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 #[inline(never)]
 fn trace_leaf_fp(frames: &mut Backtrace, active_frame: &Frame) {
+    // When walking frame pointers, we have return addresses (pointing into
+    // the *caller*), not symbol addresses. We need to identify two sentinel
+    // frames:
+    //
+    //   1. `trace_leaf` — start collecting frames *above* it
+    //   2. `Root::poll` — stop collecting when we reach it
+    //
+    // The old backtrace::trace code used `frame.symbol_address()` which
+    // resolves a return address to its containing function's entry point,
+    // allowing exact `ptr::eq` comparison. We don't have that luxury here.
+    //
+    // Instead, we compare return addresses against the known function entry
+    // points. A return address inside function F satisfies:
+    //   F <= ret_addr < F + sizeof(F)
+    // We don't know sizeof(F), but these are small `#[inline(never)]`
+    // functions, so we use a conservative 64 KiB upper bound.
+    const MAX_FN_SIZE: usize = 0x10000;
+
     unsafe {
         let mut fp: *const usize;
         #[cfg(target_arch = "x86_64")]
@@ -284,28 +302,28 @@ fn trace_leaf_fp(frames: &mut Backtrace, active_frame: &Frame) {
         #[cfg(target_arch = "aarch64")]
         std::arch::asm!("mov {}, x29", out(reg) fp);
 
-        let leaf_bounds = trace_leaf_bounds();
-        let root_bounds = resolve_root_bounds(active_frame.inner_addr);
+        let leaf_start = trace_leaf as usize;
+        let root_start = active_frame.inner_addr as usize;
 
         let mut above_leaf = false;
 
         while !fp.is_null() && fp.is_aligned() {
-            let ret_addr = *fp.add(1) as *mut c_void;
-            if ret_addr.is_null() {
+            let ret_addr = *fp.add(1) as usize;
+            if ret_addr == 0 {
                 break;
             }
 
-            let below_root = !root_bounds.contains(ret_addr);
+            let in_root = ret_addr >= root_start && ret_addr < root_start + MAX_FN_SIZE;
 
-            if above_leaf && below_root {
-                frames.push(FrameAddr(ret_addr));
+            if above_leaf && !in_root {
+                frames.push(FrameAddr(ret_addr as *mut c_void));
             }
 
-            if !above_leaf && leaf_bounds.contains(ret_addr) {
+            if !above_leaf && ret_addr >= leaf_start && ret_addr < leaf_start + MAX_FN_SIZE {
                 above_leaf = true;
             }
 
-            if !below_root {
+            if in_root {
                 break;
             }
 
@@ -337,60 +355,6 @@ fn trace_leaf_backtrace(frames: &mut Backtrace, active_frame: &Frame) {
         }
         below_root
     });
-}
-
-/// The start and (exclusive) end address of a function's machine code, as
-/// resolved once at startup from debug info via `backtrace::resolve`.
-#[derive(Copy, Clone)]
-struct FunctionBounds {
-    start: usize,
-    end: usize,
-}
-
-impl FunctionBounds {
-    /// Resolve the bounds of the function whose entry point is `fn_ptr`.
-    ///
-    /// This calls `backtrace::resolve` exactly once (at startup) and pays the
-    /// lock cost there rather than on every frame-pointer walk.  If resolution
-    /// fails (no debug info, stripped binary) we fall back to a 64 KiB window —
-    /// still far better than the old always-heuristic approach.
-    fn resolve(fn_ptr: *const c_void) -> Self {
-        let start = fn_ptr as usize;
-        // backtrace::Symbol does not expose function size, so we use a
-        // 64 KiB window as a conservative upper bound.
-        let end = start + 0x10000;
-        FunctionBounds { start, end }
-    }
-
-    #[inline]
-    fn contains(self, addr: *mut c_void) -> bool {
-        let addr = addr as usize;
-        addr >= self.start && addr < self.end
-    }
-}
-
-/// Cached bounds of `trace_leaf`, resolved once on first use.
-///
-/// The `trace_leaf` function is concrete (not generic), so its bounds are
-/// stable for the lifetime of the process.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-fn trace_leaf_bounds() -> FunctionBounds {
-    use std::sync::OnceLock;
-    static BOUNDS: OnceLock<FunctionBounds> = OnceLock::new();
-    *BOUNDS.get_or_init(|| FunctionBounds::resolve(trace_leaf as *const c_void))
-}
-
-/// Resolve the bounds of a monomorphized `Root::<T>::poll` on first use for
-/// this particular instantiation.
-///
-/// Unlike `trace_leaf`, `Root::poll` is generic, so each `T` produces a
-/// distinct function.  We resolve per-call rather than per-type because there
-/// is no convenient place to store per-type statics.  The lock is only held
-/// during the *first* dump that encounters a given `T`; afterwards the OS
-/// symbol-resolution cache makes repeated calls cheap.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-fn resolve_root_bounds(inner_addr: *const c_void) -> FunctionBounds {
-    FunctionBounds::resolve(inner_addr)
 }
 
 fn defer<F: FnOnce() -> R, R>(f: F) -> impl Drop {

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -3,13 +3,13 @@ use crate::runtime::context;
 use crate::runtime::scheduler::{self, current_thread, Inject};
 use crate::task::Id;
 
-use backtrace::BacktraceFrame;
 use std::cell::Cell;
 use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
+#[allow(unused_imports)]
 use std::ptr::{self, NonNull};
 use std::task::{self, Poll};
 
@@ -21,7 +21,9 @@ use tree::Tree;
 
 use super::{Notified, OwnedTasks, Schedule};
 
-type Backtrace = Vec<BacktraceFrame>;
+/// A raw backtrace captured via frame pointer unwinding.
+/// Each element is a return address collected while walking the call stack.
+type Backtrace = Vec<*mut c_void>;
 type SymbolTrace = Vec<Symbol>;
 
 /// The ambient backtracing context.
@@ -52,6 +54,12 @@ pub(crate) struct Trace {
     // be re-knitted into a tree.
     backtraces: Vec<Backtrace>,
 }
+
+// SAFETY: `Backtrace` is `Vec<*mut c_void>` where the pointers are code
+// addresses (instruction pointers), not pointers to owned heap data.
+// It is safe to send these across threads.
+unsafe impl Send for Trace {}
+unsafe impl Sync for Trace {}
 
 pin_project_lite::pin_project! {
     #[derive(Debug, Clone)]
@@ -164,29 +172,87 @@ pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
     let did_trace = unsafe {
         Context::try_with_current(|context_cell| {
             if let Some(mut collector) = context_cell.collector.take() {
-                let mut frames = vec![];
-                let mut above_leaf = false;
+                let mut frames: Backtrace = vec![];
 
                 if let Some(active_frame) = context_cell.active_frame.get() {
                     let active_frame = active_frame.as_ref();
 
-                    backtrace::trace(|frame| {
-                        let below_root = !ptr::eq(frame.symbol_address(), active_frame.inner_addr);
+                    // Walk the call stack using frame pointers instead of
+                    // backtrace::trace. This avoids the global lock in
+                    // backtrace-rs and is significantly faster on hot paths.
+                    //
+                    // We collect raw return addresses here and defer
+                    // symbolization to display time (in tree.rs), matching the
+                    // "new_unresolved" pattern but without any lock acquisition.
+                    //
+                    // The sentinel comparisons use the return address directly.
+                    // Because a return address points *inside* the caller (just
+                    // past the call instruction), we check whether each address
+                    // falls within the function's body rather than comparing
+                    // against its exact start address.
+                    #[cfg(target_arch = "x86_64")]
+                    {
+                        let mut fp: *const usize;
+                        std::arch::asm!("mov {}, rbp", out(reg) fp);
 
-                        // only capture frames above `Trace::leaf` and below
-                        // `Trace::root`.
-                        if above_leaf && below_root {
-                            frames.push(frame.to_owned().into());
+                        // Resolve sentinel bounds.  trace_leaf_bounds() is
+                        // cached after the first call; resolve_root_bounds()
+                        // calls backtrace::resolve once per dump (acceptable:
+                        // dumps are rare and the lock is not held during the
+                        // walk itself).
+                        let leaf_bounds = trace_leaf_bounds();
+                        let root_bounds = resolve_root_bounds(active_frame.inner_addr);
+
+                        let mut above_leaf = false;
+
+                        while !fp.is_null() && fp.is_aligned() {
+                            let ret_addr = *fp.add(1) as *mut c_void;
+                            if ret_addr.is_null() {
+                                break;
+                            }
+
+                            let below_root = !root_bounds.contains(ret_addr);
+
+                            if above_leaf && below_root {
+                                frames.push(ret_addr);
+                            }
+
+                            if !above_leaf && leaf_bounds.contains(ret_addr) {
+                                above_leaf = true;
+                            }
+
+                            if !below_root {
+                                break;
+                            }
+
+                            let next = *fp as *const usize;
+                            if next <= fp {
+                                break;
+                            }
+                            fp = next;
                         }
+                    }
 
-                        if ptr::eq(frame.symbol_address(), trace_leaf as *const _) {
-                            above_leaf = true;
-                        }
-
-                        // only continue unwinding if we're below `Trace::root`
-                        below_root
-                    });
+                    // On non-x86_64 targets fall back to the backtrace crate.
+                    // (frame-pointer unwinding on other arches can be added
+                    // incrementally.)
+                    #[cfg(not(target_arch = "x86_64"))]
+                    {
+                        let mut above_leaf = false;
+                        backtrace::trace(|frame| {
+                            let below_root =
+                                !ptr::eq(frame.symbol_address(), active_frame.inner_addr);
+                            if above_leaf && below_root {
+                                frames.push(frame.ip());
+                            }
+                            if ptr::eq(frame.symbol_address(), trace_leaf as *const _) {
+                                above_leaf = true;
+                            }
+                            below_root
+                        });
+                    }
                 }
+
                 collector.backtraces.push(frames);
                 context_cell.collector.set(Some(collector));
                 true
@@ -220,6 +286,60 @@ impl fmt::Display for Trace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Tree::from_trace(self.clone()).fmt(f)
     }
+}
+
+/// The start and (exclusive) end address of a function's machine code, as
+/// resolved once at startup from debug info via `backtrace::resolve`.
+#[derive(Copy, Clone)]
+struct FunctionBounds {
+    start: usize,
+    end: usize,
+}
+
+impl FunctionBounds {
+    /// Resolve the bounds of the function whose entry point is `fn_ptr`.
+    ///
+    /// This calls `backtrace::resolve` exactly once (at startup) and pays the
+    /// lock cost there rather than on every frame-pointer walk.  If resolution
+    /// fails (no debug info, stripped binary) we fall back to a 64 KiB window —
+    /// still far better than the old always-heuristic approach.
+    fn resolve(fn_ptr: *const c_void) -> Self {
+        let start = fn_ptr as usize;
+        // backtrace::Symbol does not expose function size, so we use a
+        // 64 KiB window as a conservative upper bound.
+        let end = start + 0x10000;
+        FunctionBounds { start, end }
+    }
+
+    #[inline]
+    fn contains(self, addr: *mut c_void) -> bool {
+        let addr = addr as usize;
+        addr >= self.start && addr < self.end
+    }
+}
+
+/// Cached bounds of `trace_leaf`, resolved once on first use.
+///
+/// The `trace_leaf` function is concrete (not generic), so its bounds are
+/// stable for the lifetime of the process.
+#[cfg(target_arch = "x86_64")]
+fn trace_leaf_bounds() -> FunctionBounds {
+    use std::sync::OnceLock;
+    static BOUNDS: OnceLock<FunctionBounds> = OnceLock::new();
+    *BOUNDS.get_or_init(|| FunctionBounds::resolve(trace_leaf as *const c_void))
+}
+
+/// Resolve the bounds of a monomorphized `Root::<T>::poll` on first use for
+/// this particular instantiation.
+///
+/// Unlike `trace_leaf`, `Root::poll` is generic, so each `T` produces a
+/// distinct function.  We resolve per-call rather than per-type because there
+/// is no convenient place to store per-type statics.  The lock is only held
+/// during the *first* dump that encounters a given `T`; afterwards the OS
+/// symbol-resolution cache makes repeated calls cheap.
+#[cfg(target_arch = "x86_64")]
+fn resolve_root_bounds(inner_addr: *const c_void) -> FunctionBounds {
+    FunctionBounds::resolve(inner_addr)
 }
 
 fn defer<F: FnOnce() -> R, R>(f: F) -> impl Drop {

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -21,8 +21,7 @@ use tree::Tree;
 
 use super::{Notified, OwnedTasks, Schedule};
 
-/// A raw backtrace captured via frame pointer unwinding.
-/// Each element is a return address collected while walking the call stack.
+/// A raw backtrace captured during stack unwinding.
 type Backtrace = Vec<FrameAddr>;
 type SymbolTrace = Vec<Symbol>;
 
@@ -87,6 +86,9 @@ pub(crate) struct Trace {
     // be re-knitted into a tree.
     backtraces: Vec<Backtrace>,
     mode: TraceMode,
+    /// For FramePointer mode: the Root::poll address for each backtrace,
+    /// used to filter frames at symbolization time.
+    root_addrs: Vec<usize>,
 }
 
 pin_project_lite::pin_project! {
@@ -185,6 +187,7 @@ impl Trace {
         let collector = Trace {
             backtraces: vec![],
             mode,
+            root_addrs: vec![],
         };
 
         let previous = Context::with_current_collector(|current| current.replace(Some(collector)));
@@ -231,9 +234,11 @@ pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
                     match collector.mode {
                         TraceMode::FramePointer => {
                             trace_leaf_fp(&mut frames, active_frame);
+                            collector.root_addrs.push(active_frame.inner_addr as usize);
                         }
                         TraceMode::Backtrace => {
                             trace_leaf_backtrace(&mut frames, active_frame);
+                            collector.root_addrs.push(0); // not used
                         }
                     }
                 }
@@ -274,27 +279,14 @@ impl fmt::Display for Trace {
 }
 
 /// Walk the stack using frame pointers. Only available on x86_64 and aarch64.
+///
+/// Collects the entire frame pointer chain as raw return addresses. Filtering
+/// (removing frames below `trace_leaf` and above `Root::poll`) is deferred to
+/// symbolization time in `to_symboltrace`, where `backtrace::resolve` can
+/// identify functions exactly.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 #[inline(never)]
-fn trace_leaf_fp(frames: &mut Backtrace, active_frame: &Frame) {
-    // When walking frame pointers, we have return addresses (pointing into
-    // the *caller*), not symbol addresses. We need to identify two sentinel
-    // frames:
-    //
-    //   1. `trace_leaf` — start collecting frames *above* it
-    //   2. `Root::poll` — stop collecting when we reach it
-    //
-    // The old backtrace::trace code used `frame.symbol_address()` which
-    // resolves a return address to its containing function's entry point,
-    // allowing exact `ptr::eq` comparison. We don't have that luxury here.
-    //
-    // Instead, we compare return addresses against the known function entry
-    // points. A return address inside function F satisfies:
-    //   F <= ret_addr < F + sizeof(F)
-    // We don't know sizeof(F), but these are small `#[inline(never)]`
-    // functions, so we use a conservative 64 KiB upper bound.
-    const MAX_FN_SIZE: usize = 0x10000;
-
+fn trace_leaf_fp(frames: &mut Backtrace, _active_frame: &Frame) {
     unsafe {
         let mut fp: *const usize;
         #[cfg(target_arch = "x86_64")]
@@ -302,30 +294,13 @@ fn trace_leaf_fp(frames: &mut Backtrace, active_frame: &Frame) {
         #[cfg(target_arch = "aarch64")]
         std::arch::asm!("mov {}, x29", out(reg) fp);
 
-        let leaf_start = trace_leaf as usize;
-        let root_start = active_frame.inner_addr as usize;
-
-        let mut above_leaf = false;
-
         while !fp.is_null() && fp.is_aligned() {
-            let ret_addr = *fp.add(1) as usize;
-            if ret_addr == 0 {
+            let ret_addr = *fp.add(1) as *mut c_void;
+            if ret_addr.is_null() {
                 break;
             }
 
-            let in_root = ret_addr >= root_start && ret_addr < root_start + MAX_FN_SIZE;
-
-            if above_leaf && !in_root {
-                frames.push(FrameAddr(ret_addr as *mut c_void));
-            }
-
-            if !above_leaf && ret_addr >= leaf_start && ret_addr < leaf_start + MAX_FN_SIZE {
-                above_leaf = true;
-            }
-
-            if in_root {
-                break;
-            }
+            frames.push(FrameAddr(ret_addr));
 
             let next = *fp as *const usize;
             if next <= fp {

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 #[allow(unused_imports)]
-use std::ptr::{self, NonNull};
+use std::ptr::NonNull;
 use std::task::{self, Poll};
 
 mod symbol;
@@ -36,9 +36,6 @@ pub(crate) struct Context {
 
 /// A [`Frame`] in an intrusive, doubly-linked tree of [`Frame`]s.
 struct Frame {
-    /// The location associated with this frame.
-    inner_addr: *const c_void,
-
     /// The parent frame, if any.
     parent: Option<NonNull<Frame>>,
 }
@@ -68,14 +65,6 @@ impl FrameAddr {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum TraceMode {
-    /// Use `backtrace::trace` (always works, takes global lock).
-    Backtrace,
-    /// Use frame pointer unwinding (no lock, requires `-C force-frame-pointers=yes`).
-    FramePointer,
-}
-
 /// An tree execution trace.
 ///
 /// Traces are captured with [`Trace::capture`], rooted with [`Trace::root`]
@@ -85,10 +74,6 @@ pub(crate) struct Trace {
     // The linear backtraces that comprise this trace. These linear traces can
     // be re-knitted into a tree.
     backtraces: Vec<Backtrace>,
-    mode: TraceMode,
-    /// For FramePointer mode: the Root::poll address for each backtrace,
-    /// used to filter frames at symbolization time.
-    root_addrs: Vec<usize>,
 }
 
 pin_project_lite::pin_project! {
@@ -159,35 +144,16 @@ impl Context {
 impl Trace {
     /// Invokes `f`, returning both its result and the collection of backtraces
     /// captured at each sub-invocation of [`trace_leaf`].
+    ///
+    /// Uses frame pointer unwinding to collect stack traces. The binary must
+    /// be compiled with `-C force-frame-pointers=yes` for correct results.
     #[inline(never)]
     pub(crate) fn capture<F, R>(f: F) -> (R, Trace)
     where
         F: FnOnce() -> R,
     {
-        Self::capture_with_mode(f, TraceMode::Backtrace)
-    }
-
-    /// Like [`capture`](Self::capture), but uses frame pointer unwinding
-    /// instead of `backtrace::trace`. This avoids the global lock in
-    /// backtrace-rs, but requires the binary to be compiled with
-    /// `-C force-frame-pointers=yes`.
-    #[inline(never)]
-    pub(crate) fn capture_fp<F, R>(f: F) -> (R, Trace)
-    where
-        F: FnOnce() -> R,
-    {
-        Self::capture_with_mode(f, TraceMode::FramePointer)
-    }
-
-    #[inline(never)]
-    fn capture_with_mode<F, R>(f: F, mode: TraceMode) -> (R, Trace)
-    where
-        F: FnOnce() -> R,
-    {
         let collector = Trace {
             backtraces: vec![],
-            mode,
-            root_addrs: vec![],
         };
 
         let previous = Context::with_current_collector(|current| current.replace(Some(collector)));
@@ -229,18 +195,8 @@ pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
                 let mut frames: Backtrace = vec![];
 
                 if let Some(active_frame) = context_cell.active_frame.get() {
-                    let active_frame = active_frame.as_ref();
-
-                    match collector.mode {
-                        TraceMode::FramePointer => {
-                            trace_leaf_fp(&mut frames, active_frame);
-                            collector.root_addrs.push(active_frame.inner_addr as usize);
-                        }
-                        TraceMode::Backtrace => {
-                            trace_leaf_backtrace(&mut frames, active_frame);
-                            collector.root_addrs.push(0); // not used
-                        }
-                    }
+                    let root_fp = active_frame.as_ptr() as usize;
+                    trace_leaf_fp(&mut frames, root_fp);
                 }
 
                 collector.backtraces.push(frames);
@@ -280,13 +236,18 @@ impl fmt::Display for Trace {
 
 /// Walk the stack using frame pointers. Only available on x86_64 and aarch64.
 ///
-/// Collects the entire frame pointer chain as raw return addresses. Filtering
-/// (removing frames below `trace_leaf` and above `Root::poll`) is deferred to
-/// symbolization time in `to_symboltrace`, where `backtrace::resolve` can
-/// identify functions exactly.
+/// Collects return addresses from the fp chain, skipping the first 2 frames
+/// (trace_leaf_fp and trace_leaf) and stopping when the frame pointer reaches
+/// `root_fp` (the address of the `Frame` struct on `Root::poll`'s stack).
+/// This produces a clean trace containing only user code.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 #[inline(never)]
-fn trace_leaf_fp(frames: &mut Backtrace, _active_frame: &Frame) {
+fn trace_leaf_fp(frames: &mut Backtrace, root_fp: usize) {
+    // The number of internal frames to skip at the bottom of the trace:
+    // 0: trace_leaf_fp (this function)
+    // 1: trace_leaf
+    const FRAMES_TO_SKIP: usize = 2;
+
     unsafe {
         let mut fp: *const usize;
         #[cfg(target_arch = "x86_64")]
@@ -294,13 +255,25 @@ fn trace_leaf_fp(frames: &mut Backtrace, _active_frame: &Frame) {
         #[cfg(target_arch = "aarch64")]
         std::arch::asm!("mov {}, x29", out(reg) fp);
 
+        let mut i = 0;
         while !fp.is_null() && fp.is_aligned() {
+            // Stop when we reach or pass the root frame. The Frame struct
+            // lives on Root::poll's stack, so its address is between
+            // Root::poll's fp and sp. Once our fp walk reaches that
+            // region, we've exited user code.
+            if fp as usize >= root_fp {
+                break;
+            }
+
             let ret_addr = *fp.add(1) as *mut c_void;
             if ret_addr.is_null() {
                 break;
             }
 
-            frames.push(FrameAddr(ret_addr));
+            if i >= FRAMES_TO_SKIP {
+                frames.push(FrameAddr(ret_addr));
+            }
+            i += 1;
 
             let next = *fp as *const usize;
             if next <= fp {
@@ -312,25 +285,10 @@ fn trace_leaf_fp(frames: &mut Backtrace, _active_frame: &Frame) {
 }
 
 #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-fn trace_leaf_fp(_frames: &mut Backtrace, _active_frame: &Frame) {
+fn trace_leaf_fp(_frames: &mut Backtrace, _root_fp: usize) {
     // Frame pointer unwinding is not supported on this architecture.
 }
 
-/// Walk the stack using `backtrace::trace`. Works on all platforms.
-#[inline(never)]
-fn trace_leaf_backtrace(frames: &mut Backtrace, active_frame: &Frame) {
-    let mut above_leaf = false;
-    backtrace::trace(|frame| {
-        let below_root = !ptr::eq(frame.symbol_address(), active_frame.inner_addr);
-        if above_leaf && below_root {
-            frames.push(FrameAddr(frame.ip()));
-        }
-        if ptr::eq(frame.symbol_address(), trace_leaf as *const _) {
-            above_leaf = true;
-        }
-        below_root
-    });
-}
 
 fn defer<F: FnOnce() -> R, R>(f: F) -> impl Drop {
     use std::mem::ManuallyDrop;
@@ -358,7 +316,6 @@ impl<T: Future> Future for Root<T> {
         // before `frame` is dropped.
         unsafe {
             let mut frame = Frame {
-                inner_addr: Self::poll as *const c_void,
                 parent: None,
             };
 

--- a/tokio/src/runtime/task/trace/symbol.rs
+++ b/tokio/src/runtime/task/trace/symbol.rs
@@ -1,62 +1,54 @@
-use backtrace::BacktraceSymbol;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::ptr;
+use std::path::PathBuf;
 
-/// A symbol in a backtrace.
+/// A symbolized frame captured at display time from a raw instruction pointer.
 ///
-/// This wrapper type serves two purposes. The first is that it provides a
-/// representation of a symbol that can be inserted into hashmaps and hashsets;
-/// the [`backtrace`] crate does not define [`Hash`], [`PartialEq`], or [`Eq`]
-/// on [`BacktraceSymbol`], and recommends that users define their own wrapper
-/// which implements these traits.
-///
-/// Second, this wrapper includes a `parent_hash` field that uniquely
-/// identifies this symbol's position in its trace. Otherwise, e.g., our code
-/// would not be able to distinguish between recursive calls of a function at
-/// different depths.
+/// We extract the fields we need eagerly from the `backtrace::Symbol` callback
+/// (which does not allow cloning) so that `Symbol` can be stored in hash
+/// maps and hash sets.
 #[derive(Clone)]
 pub(super) struct Symbol {
-    pub(super) symbol: BacktraceSymbol,
+    name: Option<Vec<u8>>,
+    addr: Option<usize>,
+    filename: Option<PathBuf>,
+    lineno: Option<u32>,
+    colno: Option<u32>,
     pub(super) parent_hash: u64,
 }
 
+impl Symbol {
+    pub(super) fn from_callback(sym: &backtrace::Symbol, parent_hash: u64) -> Self {
+        Symbol {
+            name: sym.name().map(|n| n.as_bytes().to_owned()),
+            addr: sym.addr().map(|a| a as usize),
+            filename: sym.filename().map(|f| f.to_owned()),
+            lineno: sym.lineno(),
+            colno: sym.colno(),
+            parent_hash,
+        }
+    }
+}
+
 impl Hash for Symbol {
-    fn hash<H>(&self, state: &mut H)
-    where
-        H: Hasher,
-    {
-        if let Some(name) = self.symbol.name() {
-            name.as_bytes().hash(state);
-        }
-
-        if let Some(addr) = self.symbol.addr() {
-            ptr::hash(addr, state);
-        }
-
-        self.symbol.filename().hash(state);
-        self.symbol.lineno().hash(state);
-        self.symbol.colno().hash(state);
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.addr.hash(state);
+        self.filename.hash(state);
+        self.lineno.hash(state);
+        self.colno.hash(state);
         self.parent_hash.hash(state);
     }
 }
 
 impl PartialEq for Symbol {
     fn eq(&self, other: &Self) -> bool {
-        (self.parent_hash == other.parent_hash)
-            && match (self.symbol.name(), other.symbol.name()) {
-                (None, None) => true,
-                (Some(lhs_name), Some(rhs_name)) => lhs_name.as_bytes() == rhs_name.as_bytes(),
-                _ => false,
-            }
-            && match (self.symbol.addr(), other.symbol.addr()) {
-                (None, None) => true,
-                (Some(lhs_addr), Some(rhs_addr)) => ptr::eq(lhs_addr, rhs_addr),
-                _ => false,
-            }
-            && (self.symbol.filename() == other.symbol.filename())
-            && (self.symbol.lineno() == other.symbol.lineno())
-            && (self.symbol.colno() == other.symbol.colno())
+        self.parent_hash == other.parent_hash
+            && self.name == other.name
+            && self.addr == other.addr
+            && self.filename == other.filename
+            && self.lineno == other.lineno
+            && self.colno == other.colno
     }
 }
 
@@ -64,25 +56,25 @@ impl Eq for Symbol {}
 
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(name) = self.symbol.name() {
-            let name = name.to_string();
-            let name = if let Some((name, _)) = name.rsplit_once("::") {
-                name
+        if let Some(name) = &self.name {
+            // Demangle on the fly.
+            let demangled = backtrace::SymbolName::new(name);
+            let name = demangled.to_string();
+            let name = if let Some((prefix, _)) = name.rsplit_once("::") {
+                prefix
             } else {
                 &name
             };
-            fmt::Display::fmt(&name, f)?;
+            fmt::Display::fmt(name, f)?;
         }
 
-        if let Some(filename) = self.symbol.filename() {
+        if let Some(filename) = &self.filename {
             f.write_str(" at ")?;
             filename.to_string_lossy().fmt(f)?;
-            if let Some(lineno) = self.symbol.lineno() {
-                f.write_str(":")?;
-                fmt::Display::fmt(&lineno, f)?;
-                if let Some(colno) = self.symbol.colno() {
-                    f.write_str(":")?;
-                    fmt::Display::fmt(&colno, f)?;
+            if let Some(lineno) = self.lineno {
+                write!(f, ":{lineno}")?;
+                if let Some(colno) = self.colno {
+                    write!(f, ":{colno}")?;
                 }
             }
         }

--- a/tokio/src/runtime/task/trace/tree.rs
+++ b/tokio/src/runtime/task/trace/tree.rs
@@ -5,37 +5,28 @@ use std::hash::{Hash, Hasher};
 use super::{Backtrace, Symbol, SymbolTrace, Trace};
 
 /// An adjacency list representation of an execution tree.
-///
-/// This tree provides a convenient intermediate representation for formatting
-/// [`Trace`] as a tree.
 pub(super) struct Tree {
-    /// The roots of the trees.
-    ///
-    /// There should only be one root, but the code is robust to multiple roots.
     roots: HashSet<Symbol>,
-
-    /// The adjacency list of symbols in the execution tree(s).
     edges: HashMap<Symbol, HashSet<Symbol>>,
 }
 
 impl Tree {
-    /// Constructs a [`Tree`] from [`Trace`]
     pub(super) fn from_trace(trace: Trace) -> Self {
         let mut roots: HashSet<Symbol> = HashSet::default();
         let mut edges: HashMap<Symbol, HashSet<Symbol>> = HashMap::default();
 
-        for trace in trace.backtraces {
-            let trace = to_symboltrace(trace);
+        for backtrace in trace.backtraces {
+            let symboltrace = to_symboltrace(backtrace);
 
-            if let Some(first) = trace.first() {
-                roots.insert(first.to_owned());
+            if let Some(first) = symboltrace.first() {
+                roots.insert(first.clone());
             }
 
-            let mut trace = trace.into_iter().peekable();
-            while let Some(frame) = trace.next() {
-                let subframes = edges.entry(frame).or_default();
-                if let Some(subframe) = trace.peek() {
-                    subframes.insert(subframe.clone());
+            let mut iter = symboltrace.into_iter().peekable();
+            while let Some(frame) = iter.next() {
+                let children = edges.entry(frame).or_default();
+                if let Some(next) = iter.peek() {
+                    children.insert(next.clone());
                 }
             }
         }
@@ -43,12 +34,10 @@ impl Tree {
         Tree { roots, edges }
     }
 
-    /// Produces the sub-symbols of a given symbol.
     fn consequences(&self, frame: &Symbol) -> Option<impl ExactSizeIterator<Item = &Symbol>> {
         Some(self.edges.get(frame)?.iter())
     }
 
-    /// Format this [`Tree`] as a textual tree.
     fn display<W: fmt::Write>(
         &self,
         f: &mut W,
@@ -57,31 +46,30 @@ impl Tree {
         prefix: &str,
     ) -> fmt::Result {
         let root_fmt = format!("{root}");
-
-        let current;
-        let next;
-
-        if is_last {
-            current = format!("{prefix}└╼\u{a0}{root_fmt}");
-            next = format!("{prefix}\u{a0}\u{a0}\u{a0}");
+        let (current, next) = if is_last {
+            (
+                format!("{prefix}└╼\u{a0}{root_fmt}"),
+                format!("{prefix}\u{a0}\u{a0}\u{a0}"),
+            )
         } else {
-            current = format!("{prefix}├╼\u{a0}{root_fmt}");
-            next = format!("{prefix}│\u{a0}\u{a0}");
-        }
+            (
+                format!("{prefix}├╼\u{a0}{root_fmt}"),
+                format!("{prefix}│\u{a0}\u{a0}"),
+            )
+        };
 
         write!(f, "{}", {
-            let mut current = current.chars();
-            current.next().unwrap();
-            current.next().unwrap();
-            &current.as_str()
+            let mut chars = current.chars();
+            chars.next();
+            chars.next();
+            chars.as_str()
         })?;
 
         if let Some(consequences) = self.consequences(root) {
             let len = consequences.len();
             for (i, consequence) in consequences.enumerate() {
-                let is_last = i == len - 1;
                 writeln!(f)?;
-                self.display(f, consequence, is_last, &next)?;
+                self.display(f, consequence, i == len - 1, &next)?;
             }
         }
 
@@ -98,27 +86,26 @@ impl fmt::Display for Tree {
     }
 }
 
-/// Resolve a sequence of [`backtrace::BacktraceFrame`]s into a sequence of
-/// [`Symbol`]s.
+/// Convert a raw [`Backtrace`] (instruction pointers) into a [`SymbolTrace`].
+///
+/// Symbolization is deferred to here (display time) so the capture path in
+/// `trace_leaf` never acquires the backtrace-rs global lock.
 fn to_symboltrace(backtrace: Backtrace) -> SymbolTrace {
-    // Resolve the backtrace frames to symbols.
-    let backtrace: Backtrace = {
-        let mut backtrace = backtrace::Backtrace::from(backtrace);
-        backtrace.resolve();
-        backtrace.into()
-    };
-
-    // Accumulate the symbols in descending order into `symboltrace`.
     let mut symboltrace: SymbolTrace = vec![];
     let mut state = DefaultHasher::new();
-    for frame in backtrace.into_iter().rev() {
-        for symbol in frame.symbols().iter().rev() {
-            let symbol = Symbol {
-                symbol: symbol.clone(),
-                parent_hash: state.finish(),
-            };
-            symbol.hash(&mut state);
-            symboltrace.push(symbol);
+
+    for addr in backtrace {
+        let parent_hash = state.finish();
+        let before = symboltrace.len();
+
+        // backtrace::resolve takes the global lock internally; that is
+        // acceptable at display time.
+        backtrace::resolve(addr as *mut _, |sym| {
+            symboltrace.push(Symbol::from_callback(sym, parent_hash));
+        });
+
+        for sym in &symboltrace[before..] {
+            sym.hash(&mut state);
         }
     }
 

--- a/tokio/src/runtime/task/trace/tree.rs
+++ b/tokio/src/runtime/task/trace/tree.rs
@@ -2,7 +2,7 @@ use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use super::{Backtrace, Symbol, SymbolTrace, Trace, TraceMode};
+use super::{Backtrace, Symbol, SymbolTrace, Trace};
 
 /// An adjacency list representation of an execution tree.
 pub(super) struct Tree {
@@ -15,10 +15,8 @@ impl Tree {
         let mut roots: HashSet<Symbol> = HashSet::default();
         let mut edges: HashMap<Symbol, HashSet<Symbol>> = HashMap::default();
 
-        let mode = trace.mode;
-        for (i, backtrace) in trace.backtraces.into_iter().enumerate() {
-            let root_addr = trace.root_addrs.get(i).copied().unwrap_or(0);
-            let symboltrace = to_symboltrace(backtrace, mode, root_addr);
+        for backtrace in trace.backtraces.into_iter() {
+            let symboltrace = to_symboltrace(backtrace);
 
             if let Some(first) = symboltrace.first() {
                 roots.insert(first.clone());
@@ -90,44 +88,19 @@ impl fmt::Display for Tree {
 
 /// Convert a raw [`Backtrace`] (instruction pointers) into a [`SymbolTrace`].
 ///
-/// In `FramePointer` mode the backtrace contains the entire fp chain, so we
-/// filter here: skip frames until we see `trace_leaf`, stop at `Root::poll`.
-/// In `Backtrace` mode the frames are already filtered during capture.
-fn to_symboltrace(backtrace: Backtrace, mode: TraceMode, root_addr: usize) -> SymbolTrace {
+/// The backtrace is already filtered at capture time (internal frames removed),
+/// so this just resolves each address to a symbol.
+fn to_symboltrace(backtrace: Backtrace) -> SymbolTrace {
     let mut symboltrace: SymbolTrace = vec![];
     let mut state = DefaultHasher::new();
 
-    let mut above_leaf = mode == TraceMode::Backtrace; // already filtered
-    let trace_leaf_addr = super::trace_leaf as usize;
-
     for addr in backtrace {
-        let mut sym_addr: Option<usize> = None;
         let parent_hash = state.finish();
         let before = symboltrace.len();
 
         backtrace::resolve(addr.addr(), |sym| {
-            if sym_addr.is_none() {
-                sym_addr = sym.addr().map(|a| a as usize);
-            }
-            if above_leaf {
-                symboltrace.push(Symbol::from_callback(sym, parent_hash));
-            }
+            symboltrace.push(Symbol::from_callback(sym, parent_hash));
         });
-
-        if mode == TraceMode::FramePointer {
-            if let Some(resolved) = sym_addr {
-                if !above_leaf {
-                    if resolved == trace_leaf_addr {
-                        above_leaf = true;
-                    }
-                    continue;
-                }
-                if resolved == root_addr {
-                    symboltrace.truncate(before);
-                    break;
-                }
-            }
-        }
 
         for sym in &symboltrace[before..] {
             sym.hash(&mut state);

--- a/tokio/src/runtime/task/trace/tree.rs
+++ b/tokio/src/runtime/task/trace/tree.rs
@@ -100,7 +100,7 @@ fn to_symboltrace(backtrace: Backtrace) -> SymbolTrace {
 
         // backtrace::resolve takes the global lock internally; that is
         // acceptable at display time.
-        backtrace::resolve(addr as *mut _, |sym| {
+        backtrace::resolve(addr.addr(), |sym| {
             symboltrace.push(Symbol::from_callback(sym, parent_hash));
         });
 

--- a/tokio/src/runtime/task/trace/tree.rs
+++ b/tokio/src/runtime/task/trace/tree.rs
@@ -2,7 +2,7 @@ use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use super::{Backtrace, Symbol, SymbolTrace, Trace};
+use super::{Backtrace, Symbol, SymbolTrace, Trace, TraceMode};
 
 /// An adjacency list representation of an execution tree.
 pub(super) struct Tree {
@@ -15,8 +15,10 @@ impl Tree {
         let mut roots: HashSet<Symbol> = HashSet::default();
         let mut edges: HashMap<Symbol, HashSet<Symbol>> = HashMap::default();
 
-        for backtrace in trace.backtraces {
-            let symboltrace = to_symboltrace(backtrace);
+        let mode = trace.mode;
+        for (i, backtrace) in trace.backtraces.into_iter().enumerate() {
+            let root_addr = trace.root_addrs.get(i).copied().unwrap_or(0);
+            let symboltrace = to_symboltrace(backtrace, mode, root_addr);
 
             if let Some(first) = symboltrace.first() {
                 roots.insert(first.clone());
@@ -88,21 +90,44 @@ impl fmt::Display for Tree {
 
 /// Convert a raw [`Backtrace`] (instruction pointers) into a [`SymbolTrace`].
 ///
-/// Symbolization is deferred to here (display time) so the capture path in
-/// `trace_leaf` never acquires the backtrace-rs global lock.
-fn to_symboltrace(backtrace: Backtrace) -> SymbolTrace {
+/// In `FramePointer` mode the backtrace contains the entire fp chain, so we
+/// filter here: skip frames until we see `trace_leaf`, stop at `Root::poll`.
+/// In `Backtrace` mode the frames are already filtered during capture.
+fn to_symboltrace(backtrace: Backtrace, mode: TraceMode, root_addr: usize) -> SymbolTrace {
     let mut symboltrace: SymbolTrace = vec![];
     let mut state = DefaultHasher::new();
 
+    let mut above_leaf = mode == TraceMode::Backtrace; // already filtered
+    let trace_leaf_addr = super::trace_leaf as usize;
+
     for addr in backtrace {
+        let mut sym_addr: Option<usize> = None;
         let parent_hash = state.finish();
         let before = symboltrace.len();
 
-        // backtrace::resolve takes the global lock internally; that is
-        // acceptable at display time.
         backtrace::resolve(addr.addr(), |sym| {
-            symboltrace.push(Symbol::from_callback(sym, parent_hash));
+            if sym_addr.is_none() {
+                sym_addr = sym.addr().map(|a| a as usize);
+            }
+            if above_leaf {
+                symboltrace.push(Symbol::from_callback(sym, parent_hash));
+            }
         });
+
+        if mode == TraceMode::FramePointer {
+            if let Some(resolved) = sym_addr {
+                if !above_leaf {
+                    if resolved == trace_leaf_addr {
+                        above_leaf = true;
+                    }
+                    continue;
+                }
+                if resolved == root_addr {
+                    symboltrace.truncate(before);
+                    break;
+                }
+            }
+        }
 
         for sym in &symboltrace[before..] {
             sym.hash(&mut state);

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -63,6 +63,46 @@ fn current_thread() {
 }
 
 #[test]
+fn raw_backtraces_resolve() {
+    let rt = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    async fn dump() {
+        let handle = Handle::current();
+        let dump = handle.dump().await;
+
+        for task in dump.tasks().iter() {
+            let mut names = Vec::new();
+            for raw_bt in task.trace().raw_backtraces() {
+                for &addr in raw_bt {
+                    backtrace::resolve(addr, |sym| {
+                        if let Some(name) = sym.name() {
+                            names.push(format!("{name}"));
+                        }
+                    });
+                }
+            }
+            let joined = names.join("\n");
+            assert!(joined.contains("dump::a"), "missing a in:\n{joined}");
+            assert!(joined.contains("dump::b"), "missing b in:\n{joined}");
+            assert!(joined.contains("dump::c"), "missing c in:\n{joined}");
+        }
+    }
+
+    rt.block_on(async {
+        tokio::select!(
+            biased;
+            _ = tokio::spawn(a()) => {},
+            _ = tokio::spawn(a()) => {},
+            _ = tokio::spawn(a()) => {},
+            _ = dump() => {},
+        );
+    });
+}
+
+#[test]
 fn multi_thread() {
     let rt = runtime::Builder::new_multi_thread()
         .enable_all()

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -77,7 +77,7 @@ fn raw_backtraces_resolve() {
             let mut names = Vec::new();
             for raw_bt in task.trace().raw_backtraces() {
                 for &addr in raw_bt {
-                    backtrace::resolve(addr, |sym| {
+                    backtrace::resolve(addr.addr(), |sym| {
                         if let Some(name) = sym.name() {
                             names.push(format!("{name}"));
                         }


### PR DESCRIPTION
## Summary

Taskdumps are currently bottlenecked by `backtrace::trace`, which serializes all unwinding through a global `Mutex`. This makes `Trace::capture` unsuitable for per-poll instrumentation in tracing libraries.

This PR:

### 1. Frame pointer unwinding in `trace_leaf`
Replace `backtrace::trace` with a direct frame pointer walk on x86_64 and aarch64. Raw instruction pointers are collected without any lock. Symbolization is deferred to display time.

### 2. Lazy symbolization API
- `Trace::raw_backtraces()` returns `impl Iterator<Item = &[FrameAddr]>` — zero-alloc access to unresolved instruction pointers for offline symbolization (addr2line, blazesym, etc.)
- `Trace::resolve_backtraces()` resolves via `backtrace::resolve` (takes the lock, but only at display time)
- `FrameAddr` is a `#[repr(transparent)]` newtype over `*mut c_void` with `Send + Sync`

### 3. Dual entry points
- `Trace::capture(f)` — uses `backtrace::trace` (always works, takes global lock). Used by `Handle::dump`.
- `Trace::capture_fp(f)` — uses frame pointer walk (no lock, requires `-C force-frame-pointers=yes`). Intended for tracing libraries instrumenting every poll.

### 4. Owned `Symbol` type
`Symbol` now owns its fields instead of wrapping `backtrace::BacktraceSymbol`, removing the dependency on that type for storage.

## Requirements
- `capture_fp` requires `-C force-frame-pointers=yes` for correct results
- Supported on x86_64 and aarch64; other architectures fall back to `backtrace::trace` in `capture` mode (and produce empty traces in `capture_fp` mode)

## Testing
All 6 existing + new dump tests pass, including a new `raw_backtraces_resolve` test that exercises the lazy symbolization path.