### PR TITLE
trace: add configurable poll_leaf via Trace::capture_with

### DIFF
--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -3,9 +3,10 @@
 //! See [`Handle::dump`][crate::runtime::Handle::dump].
 
 use crate::task::Id;
-use std::{fmt, future::Future, path::Path};
 
-pub use crate::runtime::task::trace::Root;
+pub use crate::runtime::task::trace::{
+    Backtrace, BacktraceFrame, BacktraceSymbol, Root, Trace, TraceMeta,
+};
 
 /// A snapshot of a runtime's state.
 ///
@@ -32,258 +33,6 @@ pub struct Task {
     trace: Trace,
 }
 
-/// Represents an address that should not be dereferenced.
-///
-/// This type exists to get the auto traits correct, the public API
-/// uses raw pointers to make life easier for users.
-#[derive(Copy, Clone, Debug)]
-struct Address(*mut std::ffi::c_void);
-
-// Safe since Address should not be dereferenced
-unsafe impl Send for Address {}
-unsafe impl Sync for Address {}
-
-/// A backtrace symbol.
-///
-/// This struct provides accessors for backtrace symbols, similar to [`backtrace::BacktraceSymbol`].
-#[derive(Clone, Debug)]
-pub struct BacktraceSymbol {
-    name: Option<Box<[u8]>>,
-    name_demangled: Option<Box<str>>,
-    addr: Option<Address>,
-    filename: Option<std::path::PathBuf>,
-    lineno: Option<u32>,
-    colno: Option<u32>,
-}
-
-impl BacktraceSymbol {
-    pub(crate) fn from_backtrace_symbol(sym: &backtrace::BacktraceSymbol) -> Self {
-        let name = sym.name();
-        Self {
-            name: name.as_ref().map(|name| name.as_bytes().into()),
-            name_demangled: name.map(|name| format!("{name}").into()),
-            addr: sym.addr().map(Address),
-            filename: sym.filename().map(From::from),
-            lineno: sym.lineno(),
-            colno: sym.colno(),
-        }
-    }
-
-    /// Return the raw name of the symbol.
-    pub fn name_raw(&self) -> Option<&[u8]> {
-        self.name.as_deref()
-    }
-
-    /// Return the demangled name of the symbol.
-    pub fn name_demangled(&self) -> Option<&str> {
-        self.name_demangled.as_deref()
-    }
-
-    /// Returns the starting address of this symbol.
-    pub fn addr(&self) -> Option<*mut std::ffi::c_void> {
-        self.addr.map(|addr| addr.0)
-    }
-
-    /// Returns the file name where this function was defined. If debuginfo
-    /// is missing, this is likely to return None.
-    pub fn filename(&self) -> Option<&Path> {
-        self.filename.as_deref()
-    }
-
-    /// Returns the line number for where this symbol is currently executing.
-    ///
-    /// If debuginfo is missing, this is likely to return `None`.
-    pub fn lineno(&self) -> Option<u32> {
-        self.lineno
-    }
-
-    /// Returns the column number for where this symbol is currently executing.
-    ///
-    /// If debuginfo is missing, this is likely to return `None`.
-    pub fn colno(&self) -> Option<u32> {
-        self.colno
-    }
-}
-
-/// A backtrace frame.
-///
-/// This struct represents one stack frame in a captured backtrace, similar to [`backtrace::BacktraceFrame`].
-#[derive(Clone, Debug)]
-pub struct BacktraceFrame {
-    ip: Address,
-    symbol_address: Address,
-    symbols: Box<[BacktraceSymbol]>,
-}
-
-impl BacktraceFrame {
-    pub(crate) fn from_resolved_backtrace_frame(frame: &backtrace::BacktraceFrame) -> Self {
-        Self {
-            ip: Address(frame.ip()),
-            symbol_address: Address(frame.symbol_address()),
-            symbols: frame
-                .symbols()
-                .iter()
-                .map(BacktraceSymbol::from_backtrace_symbol)
-                .collect(),
-        }
-    }
-
-    /// Return the instruction pointer of this frame.
-    ///
-    /// See the ABI docs for your platform for the exact meaning.
-    pub fn ip(&self) -> *mut std::ffi::c_void {
-        self.ip.0
-    }
-
-    /// Returns the starting symbol address of the frame of this function.
-    pub fn symbol_address(&self) -> *mut std::ffi::c_void {
-        self.symbol_address.0
-    }
-
-    /// Return an iterator over the symbols of this backtrace frame.
-    ///
-    /// Due to inlining, it is possible for there to be multiple [`BacktraceSymbol`] items relating
-    /// to a single frame. The first symbol listed is the "innermost function",
-    /// whereas the last symbol is the outermost (last caller).
-    pub fn symbols(&self) -> impl Iterator<Item = &BacktraceSymbol> {
-        self.symbols.iter()
-    }
-}
-
-/// A captured backtrace.
-///
-/// This struct provides access to each backtrace frame, similar to [`backtrace::Backtrace`].
-#[derive(Clone, Debug)]
-pub struct Backtrace {
-    frames: Box<[BacktraceFrame]>,
-}
-
-impl Backtrace {
-    /// Return the frames in this backtrace, innermost (in a task dump,
-    /// likely to be a leaf future's poll function) first.
-    pub fn frames(&self) -> impl Iterator<Item = &BacktraceFrame> {
-        self.frames.iter()
-    }
-}
-
-/// An execution trace of a task's last poll.
-///
-/// <div class="warning">
-///
-/// Resolving a backtrace, either via the [`Display`][std::fmt::Display] impl or via
-/// [`resolve_backtraces`][Trace::resolve_backtraces], parses debuginfo, which is
-/// possibly a CPU-expensive operation that can take a platform-specific but
-/// long time to run - often over 100 milliseconds, especially if the current
-/// process's binary is big. In some cases, the platform might internally cache some of the
-/// debuginfo, so successive calls to `resolve_backtraces` might be faster than
-/// the first call, but all guarantees are platform-dependent.
-///
-/// To avoid blocking the runtime, it is recommended
-/// that you resolve backtraces inside of a [`spawn_blocking()`][crate::task::spawn_blocking]
-/// and to have some concurrency-limiting mechanism to avoid unexpected performance impact.
-/// </div>
-///
-/// See [`Handle::dump`][crate::runtime::Handle::dump].
-#[derive(Debug)]
-pub struct Trace {
-    inner: super::task::trace::Trace,
-}
-
-impl Trace {
-    /// Resolve and return a list of backtraces that are involved in polls in this trace.
-    ///
-    /// The exact backtraces included here are unstable and might change in the future,
-    /// but you can expect one [`Backtrace`] for every call to
-    /// [`poll`] to a bottom-level Tokio future - so if something like [`join!`] is
-    /// used, there will be a backtrace for each future in the join.
-    ///
-    /// [`poll`]: std::future::Future::poll
-    /// [`join!`]: macro@join
-    pub fn resolve_backtraces(&self) -> Vec<Backtrace> {
-        self.inner
-            .backtraces()
-            .iter()
-            .map(|backtrace| {
-                let mut backtrace = backtrace::Backtrace::from(backtrace.clone());
-                backtrace.resolve();
-                Backtrace {
-                    frames: backtrace
-                        .frames()
-                        .iter()
-                        .map(BacktraceFrame::from_resolved_backtrace_frame)
-                        .collect(),
-                }
-            })
-            .collect()
-    }
-
-    /// Runs the function `f` in tracing mode, and returns its result along with the resulting [`Trace`].
-    ///
-    /// This is normally called with `f` being the poll function of a future, and will give you a backtrace
-    /// that tells you what that one future is doing.
-    ///
-    /// Use [`Handle::dump`] instead if you want to know what *all the tasks* in your program are doing.
-    /// Also see [`Handle::dump`] for more documentation about dumps, but unlike [`Handle::dump`], this function
-    /// should not be much slower than calling `f` directly.
-    ///
-    /// Due to the way tracing is implemented, Tokio leaf futures will usually, instead of doing their
-    /// actual work, do the equivalent of a `yield_now` (returning a `Poll::Pending` and scheduling the
-    /// current context for execution), which means forward progress will probably not happen unless
-    /// you eventually call your future outside of `capture`.
-    ///
-    /// [`Handle::dump`]: crate::runtime::Handle::dump
-    ///
-    /// Example usage:
-    /// ```
-    /// use std::future::Future;
-    /// use std::task::Poll;
-    /// use tokio::runtime::dump::Trace;
-    ///
-    /// # async fn test_fn() {
-    /// // some future
-    /// let mut test_future = std::pin::pin!(async move { tokio::task::yield_now().await; 0 });
-    ///
-    /// // trace it once, see what it's doing
-    /// let (trace, res) = Trace::root(std::future::poll_fn(|cx| {
-    ///     let (res, trace) = Trace::capture(|| test_future.as_mut().poll(cx));
-    ///     Poll::Ready((trace, res))
-    /// })).await;
-    ///
-    /// // await it to let it finish, outside of a `capture`
-    /// let output = match res {
-    ///    Poll::Ready(output) => output,
-    ///    Poll::Pending => test_future.await,
-    /// };
-    ///
-    /// println!("{trace}");
-    /// # }
-    /// ```
-    ///
-    /// ### Nested calls
-    ///
-    /// Nested calls to `capture` might return partial traces, but will not do any other undesirable behavior (for
-    /// example, they will not panic).
-    pub fn capture<F, R>(f: F) -> (R, Trace)
-    where
-        F: FnOnce() -> R,
-    {
-        let (res, trace) = super::task::trace::Trace::capture(f);
-        (res, Trace { inner: trace })
-    }
-
-    /// Create a root for stack traces captured using [`Trace::capture`]. Stack frames above
-    /// the root will not be captured.
-    ///
-    /// Nesting multiple [`Root`] futures is fine. Captures will stop at the first root. Not having
-    /// a [`Root`] is fine as well, but there is no guarantee on where the capture will stop.
-    pub fn root<F>(f: F) -> Root<F>
-    where
-        F: Future,
-    {
-        crate::runtime::task::trace::Trace::root(f)
-    }
-}
-
 impl Dump {
     pub(crate) fn new(tasks: Vec<Task>) -> Self {
         Self {
@@ -305,11 +54,8 @@ impl Tasks {
 }
 
 impl Task {
-    pub(crate) fn new(id: Id, trace: super::task::trace::Trace) -> Self {
-        Self {
-            id,
-            trace: Trace { inner: trace },
-        }
+    pub(crate) fn new(id: Id, trace: Trace) -> Self {
+        Self { id, trace }
     }
 
     /// Returns a [task ID] that uniquely identifies this task relative to other
@@ -330,11 +76,5 @@ impl Task {
     /// A trace of this task's state.
     pub fn trace(&self) -> &Trace {
         &self.trace
-    }
-}
-
-impl fmt::Display for Trace {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
     }
 }

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -3,14 +3,13 @@ use crate::runtime::context;
 use crate::runtime::scheduler::{self, current_thread, Inject};
 use crate::task::Id;
 
-use backtrace::BacktraceFrame;
 use std::cell::Cell;
 use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::ptr::{self, NonNull};
+use std::ptr::NonNull;
 use std::task::{self, Poll};
 
 mod symbol;
@@ -21,7 +20,7 @@ use tree::Tree;
 
 use super::{Notified, OwnedTasks, Schedule};
 
-type Backtrace = Vec<BacktraceFrame>;
+type InternalBacktrace = Vec<backtrace::BacktraceFrame>;
 type SymbolTrace = Vec<Symbol>;
 
 /// The ambient backtracing context.
@@ -29,8 +28,9 @@ pub(crate) struct Context {
     /// The address of [`Trace::root`] establishes an upper unwinding bound on
     /// the backtraces in `Trace`.
     active_frame: Cell<Option<NonNull<Frame>>>,
-    /// The place to stash backtraces.
-    collector: Cell<Option<Trace>>,
+    /// The function to call at each leaf poll point during tracing. allows caching the in progress
+    /// builds which makes iterating slightly less painful
+    poll_leaf: Cell<Option<fn(&TraceMeta)>>,
 }
 
 /// A [`Frame`] in an intrusive, doubly-linked tree of [`Frame`]s.
@@ -42,15 +42,29 @@ struct Frame {
     parent: Option<NonNull<Frame>>,
 }
 
-/// An tree execution trace.
+/// An execution trace of a task's last poll.
 ///
-/// Traces are captured with [`Trace::capture`], rooted with [`Trace::root`]
-/// and leaved with [`trace_leaf`].
+/// <div class="warning">
+///
+/// Resolving a backtrace, either via the [`Display`][std::fmt::Display] impl or via
+/// [`resolve_backtraces`][Trace::resolve_backtraces], parses debuginfo, which is
+/// possibly a CPU-expensive operation that can take a platform-specific but
+/// long time to run - often over 100 milliseconds, especially if the current
+/// process's binary is big. In some cases, the platform might internally cache some of the
+/// debuginfo, so successive calls to `resolve_backtraces` might be faster than
+/// the first call, but all guarantees are platform-dependent.
+///
+/// To avoid blocking the runtime, it is recommended
+/// that you resolve backtraces inside of a [`spawn_blocking()`][crate::task::spawn_blocking]
+/// and to have some concurrency-limiting mechanism to avoid unexpected performance impact.
+/// </div>
+///
+/// See [`Handle::dump`][crate::runtime::Handle::dump].
 #[derive(Clone, Debug)]
-pub(crate) struct Trace {
+pub struct Trace {
     // The linear backtraces that comprise this trace. These linear traces can
     // be re-knitted into a tree.
-    backtraces: Vec<Backtrace>,
+    backtraces: Vec<InternalBacktrace>,
 }
 
 pin_project_lite::pin_project! {
@@ -72,7 +86,7 @@ impl Context {
     pub(crate) const fn new() -> Self {
         Context {
             active_frame: Cell::new(None),
-            collector: Cell::new(None),
+            poll_leaf: Cell::new(None),
         }
     }
 
@@ -96,108 +110,215 @@ impl Context {
         }
     }
 
-    fn with_current_collector<F, R>(f: F) -> R
-    where
-        F: FnOnce(&Cell<Option<Trace>>) -> R,
-    {
-        // SAFETY: This call can only access the collector field, so it cannot
+    /// Produces `true` if the current task is being traced; otherwise false.
+    pub(crate) fn is_tracing() -> bool {
+        // SAFETY: This call can only access the poll_leaf field, so it cannot
         // break the trace frame linked list.
         unsafe {
-            Self::try_with_current(|context| f(&context.collector)).expect(FAIL_NO_THREAD_LOCAL)
+            Self::try_with_current(|context| context.poll_leaf.get().is_some()).unwrap_or(false)
         }
     }
 
-    /// Produces `true` if the current task is being traced; otherwise false.
-    pub(crate) fn is_tracing() -> bool {
-        Self::with_current_collector(|maybe_collector| {
-            let collector = maybe_collector.take();
-            let result = collector.is_some();
-            maybe_collector.set(collector);
-            result
-        })
+    fn with_current_poll_leaf<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Cell<Option<fn(&TraceMeta)>>) -> R,
+    {
+        // SAFETY: This call can only access the poll_leaf field, so it cannot
+        // break the trace frame linked list.
+        unsafe {
+            Self::try_with_current(|context| f(&context.poll_leaf)).expect(FAIL_NO_THREAD_LOCAL)
+        }
     }
 }
 
+/// Metadata passed to the `poll_leaf` callback in [`Trace::capture_with`].
+///
+/// This struct is `#[non_exhaustive]` so that new fields can be added in
+/// the future without breaking existing callers.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct TraceMeta {
+    /// The root boundary address set by [`Root::poll`], if any.
+    ///
+    /// When using `backtrace::trace` or frame-pointer unwinding, this is the
+    /// address at which stack walking should stop. It corresponds to the
+    /// `Root::poll` function pointer.
+    pub root_addr: Option<*const std::ffi::c_void>,
+}
+
+mod trace_impl;
+
+pub use trace_impl::{Backtrace, BacktraceFrame, BacktraceSymbol};
+
 impl Trace {
-    /// Invokes `f`, returning both its result and the collection of backtraces
-    /// captured at each sub-invocation of [`trace_leaf`].
+    /// Runs the function `f` in tracing mode, and returns its result along with the resulting [`Trace`].
+    ///
+    /// This is normally called with `f` being the poll function of a future, and will give you a backtrace
+    /// that tells you what that one future is doing.
+    ///
+    /// Use [`Handle::dump`] instead if you want to know what *all the tasks* in your program are doing.
+    /// Also see [`Handle::dump`] for more documentation about dumps, but unlike [`Handle::dump`], this function
+    /// should not be much slower than calling `f` directly.
+    ///
+    /// Due to the way tracing is implemented, Tokio leaf futures will usually, instead of doing their
+    /// actual work, do the equivalent of a `yield_now` (returning a `Poll::Pending` and scheduling the
+    /// current context for execution), which means forward progress will probably not happen unless
+    /// you eventually call your future outside of `capture`.
+    ///
+    /// [`Handle::dump`]: crate::runtime::Handle::dump
+    ///
+    /// Example usage:
+    /// ```
+    /// use std::future::Future;
+    /// use std::task::Poll;
+    /// use tokio::runtime::dump::Trace;
+    ///
+    /// # async fn test_fn() {
+    /// // some future
+    /// let mut test_future = std::pin::pin!(async move { tokio::task::yield_now().await; 0 });
+    ///
+    /// // trace it once, see what it's doing
+    /// let (trace, res) = Trace::root(std::future::poll_fn(|cx| {
+    ///     let (res, trace) = Trace::capture(|| test_future.as_mut().poll(cx));
+    ///     Poll::Ready((trace, res))
+    /// })).await;
+    ///
+    /// // await it to let it finish, outside of a `capture`
+    /// let output = match res {
+    ///    Poll::Ready(output) => output,
+    ///    Poll::Pending => test_future.await,
+    /// };
+    ///
+    /// println!("{trace}");
+    /// # }
+    /// ```
+    ///
+    /// ### Nested calls
+    ///
+    /// Nested calls to `capture` might return partial traces, but will not do any other undesirable behavior (for
+    /// example, they will not panic).
     #[inline(never)]
-    pub(crate) fn capture<F, R>(f: F) -> (R, Trace)
+    pub fn capture<F, R>(f: F) -> (R, Trace)
     where
         F: FnOnce() -> R,
     {
-        let collector = Trace { backtraces: vec![] };
+        trace_impl::capture(f)
+    }
 
-        let previous = Context::with_current_collector(|current| current.replace(Some(collector)));
+    /// Runs `f` with `poll_leaf` called at each Tokio leaf future poll point.
+    ///
+    /// Unlike [`capture`][Trace::capture], this method does not collect
+    /// backtraces into a [`Trace`]. Instead, the caller provides a `poll_leaf`
+    /// function pointer that is invoked at each leaf poll and is responsible
+    /// for its own state management (e.g. via thread-locals).
+    ///
+    /// The `poll_leaf` function receives a [`TraceMeta`] reference containing
+    /// metadata about the current trace context (e.g. the root boundary address).
+    ///
+    /// While `poll_leaf` is active, every Tokio leaf future will return
+    /// `Poll::Pending` and schedule a wakeup, allowing the caller to observe
+    /// each poll point.
+    ///
+    /// [`Handle::dump`]: crate::runtime::Handle::dump
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::future::Future;
+    /// use std::task::Poll;
+    /// use tokio::runtime::dump::{Trace, TraceMeta};
+    ///
+    /// // Thread-local storage for the custom trace function.
+    /// std::thread_local! {
+    ///     static LEAF_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    /// }
+    ///
+    /// fn my_trace_leaf(_meta: &TraceMeta) {
+    ///     LEAF_COUNT.with(|c| c.set(c.get() + 1));
+    /// }
+    ///
+    /// # async fn example() {
+    /// let mut fut = std::pin::pin!(async {
+    ///     tokio::task::yield_now().await;
+    /// });
+    ///
+    /// LEAF_COUNT.with(|c| c.set(0));
+    ///
+    /// Trace::root(std::future::poll_fn(|cx| {
+    ///     Trace::capture_with(|| { let _ = fut.as_mut().poll(cx); }, my_trace_leaf);
+    ///     Poll::Ready(())
+    /// })).await;
+    ///
+    /// let count = LEAF_COUNT.with(|c| c.get());
+    /// assert!(count > 0);
+    /// # }
+    /// ```
+    #[inline(never)]
+    pub fn capture_with<F, R>(f: F, poll_leaf: fn(&TraceMeta)) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let previous = Context::with_current_poll_leaf(|current| current.replace(Some(poll_leaf)));
 
         let result = f();
 
-        let collector =
-            Context::with_current_collector(|current| current.replace(previous)).unwrap();
+        Context::with_current_poll_leaf(|current| current.set(previous));
 
-        (result, collector)
+        result
     }
 
-    /// The root of a trace.
-    #[inline(never)]
-    pub(crate) fn root<F>(future: F) -> Root<F> {
-        Root { future }
+    /// Create a root for stack traces captured using [`Trace::capture`]. Stack frames above
+    /// the root will not be captured.
+    ///
+    /// Nesting multiple [`Root`] futures is fine. Captures will stop at the first root. Not having
+    /// a [`Root`] is fine as well, but there is no guarantee on where the capture will stop.
+    pub fn root<F>(f: F) -> Root<F>
+    where
+        F: Future,
+    {
+        Root { future: f }
     }
 
-    pub(crate) fn backtraces(&self) -> &[Backtrace] {
+    pub(crate) fn backtraces(&self) -> &[InternalBacktrace] {
         &self.backtraces
+    }
+
+    fn new() -> Trace {
+        Trace { backtraces: vec![] }
+    }
+
+    fn push_backtrace(&mut self, bt: InternalBacktrace) {
+        self.backtraces.push(bt);
     }
 }
 
-/// If this is a sub-invocation of [`Trace::capture`], capture a backtrace.
+/// If this is a sub-invocation of [`Trace::capture_with`], call the active
+/// `poll_leaf` function.
 ///
-/// The captured backtrace will be returned by [`Trace::capture`].
-///
-/// Invoking this function does nothing when it is not a sub-invocation
-/// [`Trace::capture`].
+/// Invoking this function does nothing when it is not a sub-invocation of
+/// [`Trace::capture_with`].
 // This function is marked `#[inline(never)]` to ensure that it gets a distinct `Frame` in the
 // backtrace, below which frames should not be included in the backtrace (since they reflect the
 // internal implementation details of this crate).
 #[inline(never)]
 pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
-    // Safety: We don't manipulate the current context's active frame.
-    let did_trace = unsafe {
-        Context::try_with_current(|context_cell| {
-            if let Some(mut collector) = context_cell.collector.take() {
-                let mut frames = vec![];
-                let mut above_leaf = false;
+    let poll_leaf = Context::with_current_poll_leaf(|cell| cell.get());
 
-                if let Some(active_frame) = context_cell.active_frame.get() {
-                    let active_frame = active_frame.as_ref();
+    if let Some(poll_leaf) = poll_leaf {
+        let meta = TraceMeta {
+            // SAFETY: We only read active_frame, we don't modify the linked list.
+            root_addr: unsafe {
+                Context::try_with_current(|ctx| {
+                    ctx.active_frame
+                        .get()
+                        .map(|frame| frame.as_ref().inner_addr)
+                })
+                .flatten()
+            },
+        };
 
-                    backtrace::trace(|frame| {
-                        let below_root = !ptr::eq(frame.symbol_address(), active_frame.inner_addr);
+        poll_leaf(&meta);
 
-                        // only capture frames above `Trace::leaf` and below
-                        // `Trace::root`.
-                        if above_leaf && below_root {
-                            frames.push(frame.to_owned().into());
-                        }
-
-                        if ptr::eq(frame.symbol_address(), trace_leaf as *const _) {
-                            above_leaf = true;
-                        }
-
-                        // only continue unwinding if we're below `Trace::root`
-                        below_root
-                    });
-                }
-                collector.backtraces.push(frames);
-                context_cell.collector.set(Some(collector));
-                true
-            } else {
-                false
-            }
-        })
-        .unwrap_or(false)
-    };
-
-    if did_trace {
         // Use the same logic that `yield_now` uses to send out wakeups after
         // the task yields.
         context::with_scheduler(|scheduler| {

--- a/tokio/src/runtime/task/trace/trace_impl.rs
+++ b/tokio/src/runtime/task/trace/trace_impl.rs
@@ -1,0 +1,231 @@
+//! Default `backtrace::trace`-based poll_leaf implementation and
+//! backtrace symbolization types.
+//!
+//! This module is self-contained and could be extracted into its own crate
+//! in the future. Its only coupling to the rest of the trace machinery is:
+//! - `super::TraceMeta` for the root boundary address
+//! - `super::trace_leaf` as a sentinel address for frame filtering
+//! - `super::Trace` as the collector type
+
+use std::cell::Cell;
+use std::ffi::c_void;
+use std::path::Path;
+use std::ptr;
+
+use super::{trace_leaf, TraceMeta, Trace};
+
+type RawBacktrace = Vec<backtrace::BacktraceFrame>;
+
+struct State {
+    collector: Cell<Option<Trace>>,
+}
+
+std::thread_local! {
+    static STATE: State = const {
+        State {
+            collector: Cell::new(None),
+        }
+    };
+}
+
+/// Capture using the default `backtrace::trace`-based implementation.
+#[inline(never)]
+pub(super) fn capture<F, R>(f: F) -> (R, Trace)
+where
+    F: FnOnce() -> R,
+{
+    let collector = Trace::new();
+
+    let previous = STATE.with(|state| state.collector.replace(Some(collector)));
+
+    let result = Trace::capture_with(f, poll_leaf);
+
+    let collector = STATE.with(|state| state.collector.replace(previous)).unwrap();
+
+    (result, collector)
+}
+
+/// The default poll_leaf: captures a backtrace via `backtrace::trace` and
+/// pushes it into the thread-local collector.
+#[inline(never)]
+fn poll_leaf(meta: &TraceMeta) {
+    STATE.with(|state| {
+        if let Some(mut collector) = state.collector.take() {
+            let mut frames: RawBacktrace = vec![];
+            let mut above_leaf = false;
+
+            if let Some(root_addr) = meta.root_addr {
+                backtrace::trace(|frame| {
+                    let below_root = !ptr::eq(frame.symbol_address(), root_addr);
+
+                    if above_leaf && below_root {
+                        frames.push(frame.to_owned().into());
+                    }
+
+                    if ptr::eq(frame.symbol_address(), trace_leaf as *const c_void) {
+                        above_leaf = true;
+                    }
+
+                    below_root
+                });
+            }
+            collector.push_backtrace(frames);
+            state.collector.set(Some(collector));
+        }
+    });
+}
+
+// --- Symbolization / presentation types ---
+
+#[derive(Copy, Clone, Debug)]
+struct Address(*mut c_void);
+
+unsafe impl Send for Address {}
+unsafe impl Sync for Address {}
+
+/// A backtrace symbol.
+///
+/// This struct provides accessors for backtrace symbols, similar to [`backtrace::BacktraceSymbol`].
+#[derive(Clone, Debug)]
+pub struct BacktraceSymbol {
+    name: Option<Box<[u8]>>,
+    name_demangled: Option<Box<str>>,
+    addr: Option<Address>,
+    filename: Option<std::path::PathBuf>,
+    lineno: Option<u32>,
+    colno: Option<u32>,
+}
+
+impl BacktraceSymbol {
+    /// Return the raw name of the symbol.
+    pub fn name_raw(&self) -> Option<&[u8]> {
+        self.name.as_deref()
+    }
+
+    /// Return the demangled name of the symbol.
+    pub fn name_demangled(&self) -> Option<&str> {
+        self.name_demangled.as_deref()
+    }
+
+    /// Returns the starting address of this symbol.
+    pub fn addr(&self) -> Option<*mut c_void> {
+        self.addr.map(|addr| addr.0)
+    }
+
+    /// Returns the file name where this function was defined. If debuginfo
+    /// is missing, this is likely to return None.
+    pub fn filename(&self) -> Option<&Path> {
+        self.filename.as_deref()
+    }
+
+    /// Returns the line number for where this symbol is currently executing.
+    ///
+    /// If debuginfo is missing, this is likely to return `None`.
+    pub fn lineno(&self) -> Option<u32> {
+        self.lineno
+    }
+
+    /// Returns the column number for where this symbol is currently executing.
+    ///
+    /// If debuginfo is missing, this is likely to return `None`.
+    pub fn colno(&self) -> Option<u32> {
+        self.colno
+    }
+}
+
+/// A backtrace frame.
+///
+/// This struct represents one stack frame in a captured backtrace, similar to [`backtrace::BacktraceFrame`].
+#[derive(Clone, Debug)]
+pub struct BacktraceFrame {
+    ip: Address,
+    symbol_address: Address,
+    symbols: Box<[BacktraceSymbol]>,
+}
+
+impl BacktraceFrame {
+    /// Return the instruction pointer of this frame.
+    ///
+    /// See the ABI docs for your platform for the exact meaning.
+    pub fn ip(&self) -> *mut c_void {
+        self.ip.0
+    }
+
+    /// Returns the starting symbol address of the frame of this function.
+    pub fn symbol_address(&self) -> *mut c_void {
+        self.symbol_address.0
+    }
+
+    /// Return an iterator over the symbols of this backtrace frame.
+    ///
+    /// Due to inlining, it is possible for there to be multiple [`BacktraceSymbol`] items relating
+    /// to a single frame. The first symbol listed is the "innermost function",
+    /// whereas the last symbol is the outermost (last caller).
+    pub fn symbols(&self) -> impl Iterator<Item = &BacktraceSymbol> {
+        self.symbols.iter()
+    }
+}
+
+/// A captured backtrace.
+///
+/// This struct provides access to each backtrace frame, similar to [`backtrace::Backtrace`].
+#[derive(Clone, Debug)]
+pub struct Backtrace {
+    frames: Box<[BacktraceFrame]>,
+}
+
+impl Backtrace {
+    /// Return the frames in this backtrace, innermost (in a task dump,
+    /// likely to be a leaf future's poll function) first.
+    pub fn frames(&self) -> impl Iterator<Item = &BacktraceFrame> {
+        self.frames.iter()
+    }
+}
+
+impl Trace {
+    /// Resolve and return a list of backtraces that are involved in polls in this trace.
+    ///
+    /// The exact backtraces included here are unstable and might change in the future,
+    /// but you can expect one [`Backtrace`] for every call to
+    /// [`poll`] to a bottom-level Tokio future - so if something like [`join!`] is
+    /// used, there will be a backtrace for each future in the join.
+    ///
+    /// [`poll`]: std::future::Future::poll
+    /// [`join!`]: macro@join
+    pub fn resolve_backtraces(&self) -> Vec<Backtrace> {
+        self.backtraces()
+            .iter()
+            .map(|bt| {
+                let mut bt = backtrace::Backtrace::from(bt.clone());
+                bt.resolve();
+                Backtrace {
+                    frames: bt
+                        .frames()
+                        .iter()
+                        .map(|frame| {
+                            BacktraceFrame {
+                                ip: Address(frame.ip()),
+                                symbol_address: Address(frame.symbol_address()),
+                                symbols: frame
+                                    .symbols()
+                                    .iter()
+                                    .map(|sym| {
+                                        let name = sym.name();
+                                        BacktraceSymbol {
+                                            name: name.as_ref().map(|n| n.as_bytes().into()),
+                                            name_demangled: name.map(|n| format!("{n}").into()),
+                                            addr: sym.addr().map(Address),
+                                            filename: sym.filename().map(From::from),
+                                            lineno: sym.lineno(),
+                                            colno: sym.colno(),
+                                        }
+                                    })
+                                    .collect(),
+                            }
+                        })
+                        .collect(),
+                }
+            })
+            .collect()
+    }
+}

--- a/tokio/src/runtime/task/trace/tree.rs
+++ b/tokio/src/runtime/task/trace/tree.rs
@@ -2,7 +2,7 @@ use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use super::{Backtrace, Symbol, SymbolTrace, Trace};
+use super::{InternalBacktrace, Symbol, SymbolTrace, Trace};
 
 /// An adjacency list representation of an execution tree.
 ///
@@ -100,9 +100,9 @@ impl fmt::Display for Tree {
 
 /// Resolve a sequence of [`backtrace::BacktraceFrame`]s into a sequence of
 /// [`Symbol`]s.
-fn to_symboltrace(backtrace: Backtrace) -> SymbolTrace {
+fn to_symboltrace(backtrace: InternalBacktrace) -> SymbolTrace {
     // Resolve the backtrace frames to symbols.
-    let backtrace: Backtrace = {
+    let backtrace: InternalBacktrace = {
         let mut backtrace = backtrace::Backtrace::from(backtrace);
         backtrace.resolve();
         backtrace.into()

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -197,3 +197,43 @@ fn notified_during_tracing() {
         );
     });
 }
+
+/// Test that `Trace::capture_with` invokes a custom `poll_leaf` function
+/// at each leaf poll point.
+#[test]
+fn capture_with_custom_poll_leaf() {
+    use std::future::Future;
+    use std::task::Poll;
+    use tokio::runtime::dump::{Trace, TraceMeta};
+
+    std::thread_local! {
+        static CALL_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    }
+
+    fn my_trace_leaf(_meta: &TraceMeta) {
+        CALL_COUNT.with(|c| c.set(c.get() + 1));
+    }
+
+    let rt = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let mut fut = std::pin::pin!(async {
+            tokio::task::yield_now().await;
+        });
+
+        CALL_COUNT.with(|c| c.set(0));
+
+        // capture_with should call my_trace_leaf at the yield_now leaf
+        Trace::root(std::future::poll_fn(|cx| {
+            Trace::capture_with(|| { let _ = fut.as_mut().poll(cx); }, my_trace_leaf);
+            Poll::Ready(())
+        }))
+        .await;
+
+        let count = CALL_COUNT.with(|c| c.get());
+        assert!(count > 0, "custom poll_leaf was never called, count={count}");
+    });
+}


### PR DESCRIPTION
Add `Trace::capture_with(f, poll_leaf)` which allows callers to provide their own `fn(&TraceMeta)` that is called at each Tokio leaf future poll point. The caller's function manages its own state (e.g. via thread-locals) and receives a `TraceMeta` reference with context such as the root boundary address.

The existing `Trace::capture` now routes through `capture_with` with a default implementation in the `default_trace` submodule, which preserves the current `backtrace::trace` + collector behavior.

Changes:
- Add `TraceMeta` (`#[non_exhaustive]`) with `root_addr` field
- Change poll_leaf signature from `fn()` to `fn(&TraceMeta)`
- `trace_leaf` builds `TraceMeta` from Context and passes it to callback
- Add `poll_leaf: Cell<Option<fn(&TraceMeta)>>` to trace::Context
- Add `Trace::capture_with` as public API
- Move public `Trace` struct from dump.rs into trace/mod.rs, re-export from dump.rs. `resolve_backtraces` stays in dump.rs as inherent method.
- Extract default backtrace::trace impl into `trace/default_trace.rs` with its own thread-local state for future crate extraction
- Remove `collector` from Context (now in default_trace module)
- Add doc example for `capture_with`
- Add integration test for `capture_with` with a custom fn

Refs: tokio-rs/tokio#7975

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
