### PR TITLE
runtime: expose schedule latency in task hooks

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,8 @@ R-loom-time-driver:
   - any-glob-to-any-file:
     - tokio/src/runtime/time/*
     - tokio/src/runtime/time/**/*
+    - tokio/src/runtime/time_alt/*
+    - tokio/src/runtime/time_alt/**/*
 
 R-loom-current-thread:
 - changed-files:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1092,7 +1092,10 @@ jobs:
       - name: Install cargo-hack, wasmtime
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-hack,wasmtime
+          # Wasmtime v46.0.1 is the last version to support
+          # `wasm32-wasip1-threads` (which was an experiment that was never
+          # standardized):
+          tool: cargo-hack,wasmtime@46.0.1
 
       - uses: Swatinem/rust-cache@v2
       - name: WASI test tokio full
@@ -1152,7 +1155,9 @@ jobs:
       - name: Install cargo-nextest, wasmtime
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-nextest,wasmtime-cli
+          # Wasmtime v47.0.0 or later should work, but we stick with a known,
+          # specific version to avoid surprises:
+          tool: cargo-nextest,wasmtime-cli@47.0.2
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'tokio-rs'
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@v7
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.52.3", features = ["full"] }
+tokio = { version = "1.52.4", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-*[TokioConf 2026 program and tickets are now available!](https://tokioconf.com)*
-
----
-
 # Tokio
 
 A runtime for writing reliable, asynchronous, and slim applications with

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.53.0", features = ["full"] }
+tokio = { version = "1.53.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.51.3", features = ["full"] }
+tokio = { version = "1.51.4", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.52.4", features = ["full"] }
+tokio = { version = "1.53.0", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/benches/remote_spawn.rs
+++ b/benches/remote_spawn.rs
@@ -84,9 +84,7 @@ fn remote_spawn_contention(c: &mut Criterion) {
 }
 
 fn parallelism_levels() -> Vec<usize> {
-    let max_parallelism = std::thread::available_parallelism()
-        .map(|p| p.get())
-        .unwrap_or(1);
+    let max_parallelism = std::thread::available_parallelism().map_or(1, |p| p.get());
 
     [1, 2, 4, 8, 16, 32, 64]
         .into_iter()

--- a/benches/spawn_blocking.rs
+++ b/benches/spawn_blocking.rs
@@ -15,9 +15,7 @@ const NUM_BATCHES: usize = 100;
 const BATCH_SIZE: usize = 16;
 
 fn spawn_blocking_concurrency(c: &mut Criterion) {
-    let max_parallelism = std::thread::available_parallelism()
-        .map(|p| p.get())
-        .unwrap_or(1);
+    let max_parallelism = std::thread::available_parallelism().map_or(1, |p| p.get());
 
     let parallelism_levels: Vec<usize> = [1, 2, 4, 8, 16, 32, 64]
         .into_iter()

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -22,6 +22,7 @@ If you are unsure where to begin, use the following guides:
     - [Triaging a Bug Report](contributing-in-issues.md#triaging-a-bug-report)
     - [Resolving a Bug Report](contributing-in-issues.md#resolving-a-bug-report)
 - [Pull Requests](pull-requests.md)
+    - [Step-by-Step Contribution Workflow](pull-requests.md#step-by-step-contribution-workflow)
     - [Cargo Commands](pull-requests.md#cargo-commands)
     - [Performing spellcheck on Tokio codebase](pull-requests.md#performing-spellcheck-on-tokio-codebase)
     - [Tests](pull-requests.md#tests)

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -11,6 +11,65 @@ documentation) are greatly appreciated.
 > issue describing the change to solicit feedback and guidance.
 > This will increase the likelihood of the PR getting merged.
 
+### Step-by-Step Contribution Workflow
+
+Once you've found an issue you'd like to work on, follow these steps before opening a Pull Request. This workflow provides a chronological overview of the contribution process and points to the relevant documentation where additional detail is available.
+
+#### 1. Fork and Clone the Repository
+
+Fork the repository to your GitHub account and clone your fork locally.
+
+If you've previously cloned the repository, ensure your local copy is up to date before creating a new branch.
+
+```bash
+git checkout master
+git pull upstream master
+```
+
+---
+
+#### 2. Create a Feature Branch
+
+Never commit directly to your local `master` branch. Instead, create a descriptive feature branch for each change you work on.
+
+```bash
+git checkout -b my-feature
+```
+
+Using a dedicated branch keeps your default branch clean and makes it easier to update your Pull Request during code review.
+
+---
+
+#### 3. Implement Your Changes
+
+Make the code or documentation changes needed. Check your work with `git diff` to confirm the changes look correct before moving on.
+
+If your changes introduce new functionality or modify existing behavior, consider whether additional tests or documentation should also be added.
+
+---
+
+#### 4. Verify Your Changes
+
+Before opening a Pull Request, run the project's verification steps. Refer to the sections below for details on when each command should be used.
+
+---
+
+#### 5. Commit and Push Your Changes
+
+Commit your changes following the [project's commit message guidelines](#commit-message-guidelines).
+
+```bash
+git add .
+git commit -m "module: describe your change"
+git push origin my-feature
+```
+
+---
+
+#### 6. Open a Pull Request
+
+Open a Pull Request from your feature branch to the main repository. See [Opening the Pull Request](#opening-the-pull-request) for what to include and how the review process works.
+
 ### Cargo Commands
 
 Due to the extensive use of features in Tokio, you will often need to add extra

--- a/examples/echo-udp.rs
+++ b/examples/echo-udp.rs
@@ -9,6 +9,28 @@
 //!     cargo run --example connect-udp 127.0.0.1:8080
 //!
 //! Each line you type in to the `connect-udp` terminal should be echo'd back to you!
+//!
+//! # Binding to all interfaces
+//!
+//! By default this example binds to `127.0.0.1` so it is only reachable
+//! from the local machine.
+//!
+//! To listen on all interfaces instead:
+//!
+//! ```sh
+//! cargo run --example echo-udp -- 0.0.0.0:8080
+//! ```
+//!
+//! Binding to `0.0.0.0` exposes the server on all network interfaces.
+//! Only do this in trusted network environments.
+//!
+//! On multi-homed systems, a UDP socket bound to a wildcard address
+//! (`0.0.0.0` or `::`) cannot always send replies from the same local IP
+//! that received the packet. Replies may therefore originate from a
+//! different address than the client targeted. See [this Cloudflare blog
+//! post][udp-blog] for more details.
+//!
+//! [udp-blog]: https://blog.cloudflare.com/everything-you-ever-wanted-to-know-about-udp-sockets-but-were-afraid-to-ask-part-1
 
 #![warn(rust_2018_idioms)]
 

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -264,8 +264,7 @@ mod date {
                 let now = SystemTime::now();
                 let now_unix = now
                     .duration_since(SystemTime::UNIX_EPOCH)
-                    .map(|since_epoch| since_epoch.as_secs())
-                    .unwrap_or(0);
+                    .map_or(0, |since_epoch| since_epoch.as_secs());
                 if cache.unix_date != now_unix {
                     cache.update(now, now_unix);
                 }

--- a/tests-integration/tests/macros_main.rs
+++ b/tests-integration/tests/macros_main.rs
@@ -16,7 +16,6 @@ async fn spawning() -> usize {
     join.await.unwrap()
 }
 
-#[cfg(tokio_unstable)]
 #[tokio::main(flavor = "local")]
 async fn local_main() -> usize {
     let join = tokio::task::spawn_local(async { 1 });
@@ -33,6 +32,5 @@ fn shell() {
     assert_eq!(1, basic_main());
     assert_eq!(bool::default(), generic_fun::<bool>());
 
-    #[cfg(tokio_unstable)]
     assert_eq!(1, local_main());
 }

--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.7.1 (July 17th, 2026)
+
+- macros: clarify `tokio::main` expansion ([#8193])
+
+[#8193]: https://github.com/tokio-rs/tokio/pull/8193
+
 # 2.7.0 (April 3rd, 2026)
 
 - macros: stabilize `LocalRuntime` ([#7557])

--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.7.2 (July 29th, 2026)
+
+- macros: upgrade syn to v3 ([#8304])
+
+[#8304]: https://github.com/tokio-rs/tokio/pull/8304
+
 # 2.7.1 (July 17th, 2026)
 
 - macros: clarify `tokio::main` expansion ([#8193])

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.60"
 quote = "1"
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "3.0", features = ["full"] }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["full", "test-util"] }

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-macros"
 # - Remove path dependencies (if any)
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-x.y.z" git tag.
-version = "2.7.0"
+version = "2.7.1"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-macros"
 # - Remove path dependencies (if any)
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-x.y.z" git tag.
-version = "2.7.1"
+version = "2.7.2"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -326,7 +326,7 @@ fn contains_impl_trait(ty: &syn::Type) -> bool {
                     _ => false,
                 }),
                 syn::PathArguments::Parenthesized(args) => {
-                    args.inputs.iter().any(contains_impl_trait)
+                    args.inputs.iter().any(|arg| contains_impl_trait(&arg.ty))
                         || matches!(&args.output, syn::ReturnType::Type(_, t) if contains_impl_trait(t))
                 }
                 syn::PathArguments::None => false,

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -453,13 +453,13 @@ fn parse_knobs(mut input: ItemFn, is_test: bool, config: FinalConfig) -> TokenSt
         (start, end)
     };
 
-    let crate_path = config
-        .crate_name
-        .map(ToTokens::into_token_stream)
-        .unwrap_or_else(|| {
+    let crate_path = config.crate_name.map_or_else(
+        || {
             Ident::new("tokio", Span::call_site().located_at(last_stmt_start_span))
                 .into_token_stream()
-        });
+        },
+        ToTokens::into_token_stream,
+    );
 
     let use_builder = quote_spanned! {Span::call_site().located_at(last_stmt_start_span)=>
         use #crate_path::runtime::Builder;

--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,3 +1,38 @@
+# 0.1.19 (July 22nd, 2026)
+
+### Added
+
+- stream: implement `FromStream` for standard collections ([#7954], [#7966])
+- stream: implement `FusedStream` for various stream adaptors ([#7854], [#8090], [#8096])
+- stream: implement `Peekable::size_hint` ([#8109])
+- task: add `JoinSetStream` wrapper for `JoinSet` ([#8189])
+
+### Changed
+
+- stream: bump minimum required `tokio` version to `1.38.0` ([#7887])
+- stream: use cooperative budgeting in `tokio_stream::iter` ([#8218])
+- stream: update coop handling for `empty` and `once` ([#8227])
+
+### Fixed
+
+- stream: fix overflow in `StreamMap::size_hint` ([#8216])
+- stream: honor `StreamMap::next_many` limit ([#8215])
+- stream: stop polling underlying stream once `map_while` yields `None` ([#8233])
+
+[#7854]: https://github.com/tokio-rs/tokio/pull/7854
+[#7887]: https://github.com/tokio-rs/tokio/pull/7887
+[#7954]: https://github.com/tokio-rs/tokio/pull/7954
+[#7966]: https://github.com/tokio-rs/tokio/pull/7966
+[#8090]: https://github.com/tokio-rs/tokio/pull/8090
+[#8096]: https://github.com/tokio-rs/tokio/pull/8096
+[#8109]: https://github.com/tokio-rs/tokio/pull/8109
+[#8189]: https://github.com/tokio-rs/tokio/pull/8189
+[#8215]: https://github.com/tokio-rs/tokio/pull/8215
+[#8216]: https://github.com/tokio-rs/tokio/pull/8216
+[#8218]: https://github.com/tokio-rs/tokio/pull/8218
+[#8227]: https://github.com/tokio-rs/tokio/pull/8227
+[#8233]: https://github.com/tokio-rs/tokio/pull/8233
+
 # 0.1.18 (January 4th, 2026)
 
 ### Added

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-stream"
 # - Remove path dependencies (if any)
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio-test/src/macros.rs
+++ b/tokio-test/src/macros.rs
@@ -198,10 +198,7 @@ macro_rules! assert_ready_eq {
 /// ```
 #[macro_export]
 macro_rules! assert_ok {
-    ($e:expr) => {
-        assert_ok!($e,)
-    };
-    ($e:expr,) => {{
+    ($e:expr $(,)?) => {{
         use std::result::Result::*;
         match $e {
             Ok(v) => v,
@@ -241,10 +238,7 @@ macro_rules! assert_ok {
 /// ```
 #[macro_export]
 macro_rules! assert_err {
-    ($e:expr) => {
-        assert_err!($e,);
-    };
-    ($e:expr,) => {{
+    ($e:expr $(,)?) => {{
         use std::result::Result::*;
         match $e {
             Ok(v) => panic!("assertion failed: Ok({:?})", v),

--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,39 @@
+# 0.7.19 (July 21st, 2026)
+
+### Added
+
+- io: add `write_all_vectored` ([#7768], [#8159])
+- sync: add `DropGuard::token` for cancellation tokens ([#8226])
+- sync: implement `PartialEq` and `Eq` for `CancellationToken` ([#8110])
+- task: add `AbortOnDrop` ([#7855])
+- task: add `JoinMap::try_join_next` ([#8099])
+
+### Changed
+
+- codec: use `libc::memchr` for `LinesCodec` delimiter scan ([#8141])
+
+### Fixed
+
+- codec: fix `is_readable` when buffer is not empty ([#7912])
+- task: avoid replacing the `JoinQueue` waker in `try_join_next` ([#8279])
+- time: wake `DelayQueue` after resetting to expired ([#8274])
+
+### Documented
+
+- codec: document `UdpFramed` decoder errors ([#8248])
+
+[#7768]: https://github.com/tokio-rs/tokio/pull/7768
+[#7855]: https://github.com/tokio-rs/tokio/pull/7855
+[#7912]: https://github.com/tokio-rs/tokio/pull/7912
+[#8099]: https://github.com/tokio-rs/tokio/pull/8099
+[#8110]: https://github.com/tokio-rs/tokio/pull/8110
+[#8141]: https://github.com/tokio-rs/tokio/pull/8141
+[#8159]: https://github.com/tokio-rs/tokio/pull/8159
+[#8226]: https://github.com/tokio-rs/tokio/pull/8226
+[#8248]: https://github.com/tokio-rs/tokio/pull/8248
+[#8274]: https://github.com/tokio-rs/tokio/pull/8274
+[#8279]: https://github.com/tokio-rs/tokio/pull/8279
+
 # 0.7.18 (January 4th, 2026)
 
 ### Added

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-util"
 # - Remove path dependencies (if any)
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.7.x" git tag.
-version = "0.7.18"
+version = "0.7.19"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -1040,7 +1040,7 @@ impl Builder {
 
     fn num_head_bytes(&self) -> usize {
         let num = self.length_field_offset + self.length_field_len;
-        cmp::max(num, self.num_skip.unwrap_or(0))
+        cmp::max(num, self.num_skip.unwrap_or_default())
     }
 
     fn get_num_skip(&self) -> usize {

--- a/tokio-util/src/io/stream_reader.rs
+++ b/tokio-util/src/io/stream_reader.rs
@@ -158,6 +158,7 @@ pub struct StreamReader<S, B> {
     inner: S,
     // This field is not pinned.
     chunk: Option<B>,
+    eof: bool,
 }
 
 impl<S, B, E> StreamReader<S, B>
@@ -179,6 +180,7 @@ where
         Self {
             inner: stream,
             chunk: None,
+            eof: false,
         }
     }
 
@@ -277,6 +279,8 @@ where
                 // This unwrap is very sad, but it can't be avoided.
                 let buf = self.project().chunk.as_ref().unwrap().chunk();
                 return Poll::Ready(Ok(buf));
+            } else if *self.as_mut().project().eof {
+                return Poll::Ready(Ok(&[]));
             } else {
                 match self.as_mut().project().inner.poll_next(cx) {
                     Poll::Ready(Some(Ok(chunk))) => {
@@ -284,7 +288,10 @@ where
                         *self.as_mut().project().chunk = Some(chunk);
                     }
                     Poll::Ready(Some(Err(err))) => return Poll::Ready(Err(err.into())),
-                    Poll::Ready(None) => return Poll::Ready(Ok(&[])),
+                    Poll::Ready(None) => {
+                        *self.as_mut().project().eof = true;
+                        return Poll::Ready(Ok(&[]));
+                    }
                     Poll::Pending => return Poll::Pending,
                 }
             }
@@ -311,6 +318,7 @@ impl<S: Unpin, B> Unpin for StreamReader<S, B> {}
 struct StreamReaderProject<'a, S, B> {
     inner: Pin<&'a mut S>,
     chunk: &'a mut Option<B>,
+    eof: &'a mut bool,
 }
 
 impl<S, B> StreamReader<S, B> {
@@ -322,6 +330,7 @@ impl<S, B> StreamReader<S, B> {
         StreamReaderProject {
             inner: unsafe { Pin::new_unchecked(&mut me.inner) },
             chunk: &mut me.chunk,
+            eof: &mut me.eof,
         }
     }
 }

--- a/tokio-util/src/task/join_queue.rs
+++ b/tokio-util/src/task/join_queue.rs
@@ -188,6 +188,10 @@ impl<T> JoinQueue<T> {
     /// Note that on success the handle will panic on subsequent polls
     /// since it becomes consumed.
     fn try_poll_handle(jh: &mut AbortOnDropHandle<T>) -> Option<Result<T, JoinError>> {
+        if !jh.is_finished() {
+            return None;
+        }
+
         let waker = futures_util::task::noop_waker();
         let mut cx = Context::from_waker(&waker);
 

--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -580,12 +580,7 @@ impl<T> DelayQueue<T> {
     /// current task for wakeup if the value is not yet available, and returning
     /// `None` if the queue is exhausted.
     pub fn poll_expired(&mut self, cx: &mut task::Context<'_>) -> Poll<Option<Expired<T>>> {
-        if !self
-            .waker
-            .as_ref()
-            .map(|w| w.will_wake(cx.waker()))
-            .unwrap_or(false)
-        {
+        if !self.waker.as_ref().is_some_and(|w| w.will_wake(cx.waker())) {
             self.waker = Some(cx.waker().clone());
         }
 

--- a/tokio-util/src/time/wheel/mod.rs
+++ b/tokio-util/src/time/wheel/mod.rs
@@ -111,8 +111,7 @@ where
         debug_assert!({
             self.levels[level]
                 .next_expiration(self.elapsed)
-                .map(|e| e.deadline >= self.elapsed)
-                .unwrap_or(true)
+                .map_or(true, |e| e.deadline >= self.elapsed)
         });
 
         Ok(())

--- a/tokio-util/tests/io_stream_reader.rs
+++ b/tokio-util/tests/io_stream_reader.rs
@@ -33,3 +33,22 @@ async fn test_stream_reader() -> std::io::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_stream_reader_does_not_poll_after_eof() -> std::io::Result<()> {
+    // the first poll of this stream will return `Poll::Ready(None)`,
+    // and the second poll will panic
+    let stream = futures::stream::unfold((), |_| async { None::<(std::io::Result<Bytes>, ())> });
+    let read = StreamReader::new(stream);
+    tokio::pin!(read);
+    let mut buf = [0; 1];
+
+    // the first poll hits the inner stream,
+    // and the inner stream returns `Poll::Ready(None)`.
+    assert_eq!(read.read(&mut buf).await?, 0);
+    // the second poll doesn't hit the inner stream,
+    // so this `.read()` doesn't panic.
+    assert_eq!(read.read(&mut buf).await?, 0);
+
+    Ok(())
+}

--- a/tokio-util/tests/task_join_map.rs
+++ b/tokio-util/tests/task_join_map.rs
@@ -581,7 +581,6 @@ mod spawn_local {
         map.spawn_local((), async {});
     }
 
-    #[cfg(tokio_unstable)]
     mod local_runtime {
         use super::*;
 
@@ -693,7 +692,6 @@ mod spawn_local {
 mod spawn_local_on {
     use super::*;
 
-    #[cfg(tokio_unstable)]
     mod local_runtime {
         use super::*;
 

--- a/tokio-util/tests/task_join_queue.rs
+++ b/tokio-util/tests/task_join_queue.rs
@@ -1,5 +1,8 @@
 #![warn(rust_2018_idioms)]
 
+use std::task::Context;
+
+use futures_test::task::new_count_waker;
 use tokio::sync::oneshot;
 use tokio::task::yield_now;
 use tokio::time::Duration;
@@ -274,6 +277,60 @@ async fn test_join_queue_try_join_next() {
     assert!(queue.try_join_next().is_some());
     assert!(queue.is_empty());
     check_try_join_next_is_noop(&mut queue);
+}
+
+#[tokio::test]
+async fn test_join_queue_try_join_next_does_not_replace_waker() {
+    let (send, recv) = oneshot::channel();
+    let mut queue = JoinQueue::new();
+    queue.spawn(async move {
+        recv.await.unwrap();
+        42
+    });
+
+    let (waker, wake_count) = new_count_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    assert_pending!(queue.poll_join_next(&mut cx));
+    assert_eq!(wake_count, 0);
+    assert!(queue.try_join_next().is_none());
+
+    send.send(()).unwrap();
+    yield_now().await;
+
+    assert_eq!(wake_count, 1);
+    assert_eq!(
+        assert_ready!(queue.poll_join_next(&mut cx))
+            .unwrap()
+            .unwrap(),
+        42
+    );
+}
+
+#[tokio::test]
+async fn test_join_queue_try_join_next_with_id_does_not_replace_waker() {
+    let (send, recv) = oneshot::channel();
+    let mut queue = JoinQueue::new();
+    queue.spawn(async move {
+        recv.await.unwrap();
+        42
+    });
+
+    let (waker, wake_count) = new_count_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    assert_pending!(queue.poll_join_next_with_id(&mut cx));
+    assert_eq!(wake_count, 0);
+    assert!(queue.try_join_next_with_id().is_none());
+
+    send.send(()).unwrap();
+    yield_now().await;
+
+    assert_eq!(wake_count, 1);
+    let (_, output) = assert_ready!(queue.poll_join_next_with_id(&mut cx))
+        .unwrap()
+        .unwrap();
+    assert_eq!(output, 42);
 }
 
 #[tokio::test]

--- a/tokio-util/tests/task_tracker.rs
+++ b/tokio-util/tests/task_tracker.rs
@@ -1,7 +1,6 @@
 #![warn(rust_2018_idioms)]
 
 use futures::future::pending;
-#[cfg(tokio_unstable)]
 use std::rc::Rc;
 use tokio::sync::mpsc;
 use tokio::task::LocalSet;
@@ -182,7 +181,6 @@ fn notify_many() {
     }
 }
 
-#[cfg(tokio_unstable)]
 mod spawn {
     use super::*;
 
@@ -209,7 +207,6 @@ mod spawn {
     }
 }
 
-#[cfg(tokio_unstable)]
 mod spawn_local {
     use super::*;
 
@@ -278,7 +275,6 @@ mod spawn_local {
 mod spawn_local_on {
     use super::*;
 
-    #[cfg(tokio_unstable)]
     mod local_runtime {
         use super::*;
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.51.4 (July 16th, 2026)
+
+### Fixed
+
+- runtime: don't skip the driver when `before_park` schedules work ([#8222])
+
+[#8222]: https://github.com/tokio-rs/tokio/pull/8222
+
 # 1.51.3 (May 8th, 2026)
 
 ### Fixed

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,89 @@
+# 1.53.0 (July 17th, 2026)
+
+### Added
+
+- fs: implement `From<OwnedFd>` and `From<OwnedHandle>` for `File` ([#8266])
+- metrics: add task schedule latency metric ([#7986])
+- net: add `SocketAddr` methods to Unix sockets ([#8144])
+
+### Changed
+
+- io: add `#[inline]` to IO trait impls for in-memory types ([#8242])
+- net: implement UCred::pid on FreeBSD ([#8086])
+- net: support Nuttx target os ([#8259])
+- signal: refactor global variables on Windows ([#8231])
+- sync: `mpsc::{Receiver,UnboundedReceiver}` now drops waker on drop, even if there are still senders ([#8095])
+- taskdump: support taskdumps on s390x ([#8192])
+- time: add `#[track_caller]` to `timeout_at()` ([#8077])
+- time: consolidate mutex locks on spurious poll ([#8124])
+- time: defer waker clone on spurious poll ([#8107])
+- time: move lazy-registration state into `Sleep` ([#8132])
+- tracing: remove unnecessary span clone ([#8126])
+
+### Fixed
+
+- io: do not treat zero-length reads as EOF in `Chain` ([#8251])
+- net: use getpeereid for QNX peer credentials ([#8270])
+- runtime: avoid illegal state in `FastRand` ([#8078])
+- sync: wake mpsc receiver when a queued `reserve[_many]` returns permits ([#8260])
+- taskdump: skip double wake on `Trace::capture`/`Trace::trace_with` ([#8043])
+- time: avoid stack overflow in runtime constructor ([#8093])
+- time (alt timer): ensure timers stay in the same runtime after `.reset()` ([#8169])
+
+### IO uring (unstable)
+
+- fs: use io-uring for `fs::try_exists` ([#8080])
+- fs: use io-uring for renaming files ([#7800])
+- rt: flush io-uring CQE in case of CQE overflow ([#8277])
+
+### Documented
+
+- docs: clarify cancel safety wording ([#8181])
+- fs: clarify `create_dir_all` succeeds if path exists ([#8149])
+- io: add warning about stdout reordering with multiple handles ([#8276])
+- net: document pipe `try_read*`/`try_write*` readiness behavior ([#8032])
+- runtime: document interaction with fork() ([#8202])
+- sync: clarify broadcast lagging semantics ([#8239])
+- sync: document memory ordering guarantees for Semaphore ([#8119])
+- task: explain why `yield_now` defers its waker ([#8254])
+- time: add panic docs to `timeout_at()` ([#8077])
+- time: fix reversed poll order in timeout doc ([#8214])
+
+[#7800]: https://github.com/tokio-rs/tokio/pull/7800
+[#7986]: https://github.com/tokio-rs/tokio/pull/7986
+[#8032]: https://github.com/tokio-rs/tokio/pull/8032
+[#8043]: https://github.com/tokio-rs/tokio/pull/8043
+[#8077]: https://github.com/tokio-rs/tokio/pull/8077
+[#8078]: https://github.com/tokio-rs/tokio/pull/8078
+[#8080]: https://github.com/tokio-rs/tokio/pull/8080
+[#8086]: https://github.com/tokio-rs/tokio/pull/8086
+[#8093]: https://github.com/tokio-rs/tokio/pull/8093
+[#8095]: https://github.com/tokio-rs/tokio/pull/8095
+[#8107]: https://github.com/tokio-rs/tokio/pull/8107
+[#8119]: https://github.com/tokio-rs/tokio/pull/8119
+[#8124]: https://github.com/tokio-rs/tokio/pull/8124
+[#8126]: https://github.com/tokio-rs/tokio/pull/8126
+[#8132]: https://github.com/tokio-rs/tokio/pull/8132
+[#8144]: https://github.com/tokio-rs/tokio/pull/8144
+[#8149]: https://github.com/tokio-rs/tokio/pull/8149
+[#8169]: https://github.com/tokio-rs/tokio/pull/8169
+[#8181]: https://github.com/tokio-rs/tokio/pull/8181
+[#8192]: https://github.com/tokio-rs/tokio/pull/8192
+[#8193]: https://github.com/tokio-rs/tokio/pull/8193
+[#8202]: https://github.com/tokio-rs/tokio/pull/8202
+[#8214]: https://github.com/tokio-rs/tokio/pull/8214
+[#8231]: https://github.com/tokio-rs/tokio/pull/8231
+[#8239]: https://github.com/tokio-rs/tokio/pull/8239
+[#8242]: https://github.com/tokio-rs/tokio/pull/8242
+[#8251]: https://github.com/tokio-rs/tokio/pull/8251
+[#8254]: https://github.com/tokio-rs/tokio/pull/8254
+[#8259]: https://github.com/tokio-rs/tokio/pull/8259
+[#8260]: https://github.com/tokio-rs/tokio/pull/8260
+[#8266]: https://github.com/tokio-rs/tokio/pull/8266
+[#8270]: https://github.com/tokio-rs/tokio/pull/8270
+[#8276]: https://github.com/tokio-rs/tokio/pull/8276
+[#8277]: https://github.com/tokio-rs/tokio/pull/8277
+
 # 1.52.4 (July 16th, 2026)
 
 ### Fixed

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 1.53.1 (July 20th, 2026)
+
+### Fixed
+
+- signal: restore MSRV by removing `OnceLock::wait` from the Windows handler ([#8300])
+
+### Fixed (unstable)
+
+- time: fix alt timer cancellation and insertion race ([#8252])
+
+### Documented
+
+- runtime: remove dead link definition in Runtime::block_on ([#8301])
+
+[#8252]: https://github.com/tokio-rs/tokio/pull/8252
+[#8300]: https://github.com/tokio-rs/tokio/pull/8300
+[#8301]: https://github.com/tokio-rs/tokio/pull/8301
+
 # 1.53.0 (July 17th, 2026)
 
 ### Added

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 1.52.4 (July 16th, 2026)
+
+### Fixed
+
+- runtime: don't skip the driver when `before_park` schedules work ([#8222])
+
+### Fixed (unstable)
+
+- taskdump: remove crate disambiguators from output ([#8264])
+
+[#8264]: https://github.com/tokio-rs/tokio/pull/8264
+
 # 1.52.3 (May 8th, 2026)
 
 ### Fixed

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.53.0"
+version = "1.53.1"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.51.3"
+version = "1.51.4"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.52.3"
+version = "1.52.4"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.52.4"
+version = "1.53.0"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.52.3", features = ["full"] }
+tokio = { version = "1.52.4", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -1,7 +1,3 @@
-*[TokioConf 2026 program and tickets are now available!](https://tokioconf.com)*
-
----
-
 # Tokio
 
 A runtime for writing reliable, asynchronous, and slim applications with

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.53.0", features = ["full"] }
+tokio = { version = "1.53.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.51.3", features = ["full"] }
+tokio = { version = "1.51.4", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.52.4", features = ["full"] }
+tokio = { version = "1.53.0", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -1053,7 +1053,7 @@ impl Inner {
         if driver_handle
             .check_and_init(io_uring::opcode::Read::CODE)
             .await
-            .unwrap_or(false)
+            .unwrap_or_default()
         {
             let fd: crate::io::uring::utils::ArcFd = std;
             Self::uring_read(fd, buf, max_buf_size).await

--- a/tokio/src/fs/mod.rs
+++ b/tokio/src/fs/mod.rs
@@ -16,9 +16,17 @@
 //! such as hangs during runtime shutdown. For special files, you should use a
 //! dedicated type such as [`tokio::net::unix::pipe`] or [`AsyncFd`] instead.
 //!
-//! Currently, Tokio will always use [`spawn_blocking`] on all platforms, but it
-//! may be changed to use asynchronous file system APIs such as io_uring in the
-//! future.
+//! Tokio currently uses [`spawn_blocking`] on all platforms, but also uses
+//! io_uring for file operations on Linux when compiled with `tokio_unstable`.
+//! Operations that cannot be cancelled with [`spawn_blocking`] may possibly
+//! be cancelled with io_uring.
+//!
+//! # Cancellation
+//!
+//! Cancelling a future from this module will stop waiting for the result, but
+//! the underlying blocking operation will continue to run on the thread pool.
+//! For example, cancelling a [`write()`] future after it has been
+//! polled will still result in the data being written to disk.
 //!
 //! # Usage
 //!

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -83,7 +83,7 @@ where
                 .rev()
                 .take(MAX_BYTES_PER_CHAR)
                 .position(|byte| *byte < 0b1000_0000 || *byte >= 0b1100_0000)
-                .unwrap_or(0)
+                .unwrap_or_default()
                 + 1;
             buf = &buf[..buf.len() - trailing_incomplete_char_size];
         }

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -185,7 +185,7 @@ impl Drop for DuplexStream {
 /// Creates unidirectional buffer that acts like in memory pipe.
 ///
 /// The `max_buf_size` argument is the maximum amount of bytes that can be
-/// written to a buffer before the it returns `Poll::Pending`.
+/// written to a buffer before it returns `Poll::Pending`.
 ///
 /// # Unify reader and writer
 ///
@@ -217,7 +217,7 @@ impl SimplexStream {
     /// version with separate reader and writer you can use [`simplex`] function.
     ///
     /// The `max_buf_size` argument is the maximum amount of bytes that can be
-    /// written to a buffer before the it returns `Poll::Pending`.
+    /// written to a buffer before it returns `Poll::Pending`.
     #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
     pub fn new_unsplit(max_buf_size: usize) -> SimplexStream {
         SimplexStream {

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -250,6 +250,10 @@ impl SimplexStream {
         cx: &mut task::Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
         if self.buffer.has_remaining() {
             let max = self.buffer.remaining().min(buf.remaining());
             buf.put_slice(&self.buffer[..max]);
@@ -278,6 +282,10 @@ impl SimplexStream {
         if self.is_closed {
             return Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()));
         }
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
         let avail = self.max_buf_size - self.buffer.len();
         if avail == 0 {
             self.write_waker = Some(cx.waker().clone());
@@ -300,6 +308,10 @@ impl SimplexStream {
         if self.is_closed {
             return Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()));
         }
+        if bufs.iter().all(|buf| buf.is_empty()) {
+            return Poll::Ready(Ok(0));
+        }
+
         let avail = self.max_buf_size - self.buffer.len();
         if avail == 0 {
             self.write_waker = Some(cx.waker().clone());

--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -69,9 +69,10 @@ pub(crate) use self::impl_aix::get_peer_cred;
 
 #[cfg(any(
     target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "hurd",
     target_os = "nuttx",
-    target_os = "vita",
-    target_os = "hurd"
+    target_os = "vita"
 ))]
 pub(crate) use self::impl_noproc::get_peer_cred;
 
@@ -400,9 +401,10 @@ pub(crate) mod impl_aix {
 
 #[cfg(any(
     target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "hurd",
     target_os = "nuttx",
-    target_os = "vita",
-    target_os = "hurd"
+    target_os = "vita"
 ))]
 pub(crate) mod impl_noproc {
     use crate::net::unix::UnixStream;

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -74,11 +74,8 @@ impl SpawnerMetrics {
 }
 
 struct Inner {
-    /// State shared between worker threads.
-    shared: Mutex<Shared>,
-
-    /// Pool threads wait on this.
-    condvar: Condvar,
+    /// Queue + notification implementation.
+    inner_impl: InnerImpl,
 
     /// Spawned threads use this name.
     thread_name: ThreadNameFn,
@@ -102,9 +99,35 @@ struct Inner {
     metrics: SpawnerMetrics,
 }
 
-struct Shared {
+/// Per-variant queue + notification + lock topology.
+enum InnerImpl {
+    Locked(LockedImpl),
+}
+
+/// Single-mutex + condvar implementation.
+struct LockedImpl {
+    mutex: Mutex<LockedInner>,
+    condvar: Condvar,
+}
+
+struct LockedInner {
     queue: VecDeque<Task>,
     num_notify: u32,
+    /// Thread-management state. Split apart so that it's re-usable in a
+    /// sharded queue implementation.
+    thread_mgmt_state: ThreadManagementState,
+}
+
+/// State handed back from `InnerImpl::begin_shutdown` to the caller so it
+/// can join the worker threads after the wait completes: an optional
+/// previously-timed-out worker, plus the map of currently-running workers.
+type ShutdownHandles = (
+    Option<thread::JoinHandle<()>>,
+    HashMap<usize, thread::JoinHandle<()>>,
+);
+
+/// Thread-management state used by every `InnerImpl` variant.
+struct ThreadManagementState {
     shutdown: bool,
     shutdown_tx: Option<shutdown::Sender>,
     /// Prior to shutdown, we clean up `JoinHandles` by having each timed-out
@@ -214,16 +237,20 @@ impl BlockingPool {
         BlockingPool {
             spawner: Spawner {
                 inner: Arc::new(Inner {
-                    shared: Mutex::new(Shared {
-                        queue: VecDeque::new(),
-                        num_notify: 0,
-                        shutdown: false,
-                        shutdown_tx: Some(shutdown_tx),
-                        last_exiting_thread: None,
-                        worker_threads: HashMap::new(),
-                        worker_thread_index: 0,
+                    inner_impl: InnerImpl::Locked(LockedImpl {
+                        mutex: Mutex::new(LockedInner {
+                            queue: VecDeque::new(),
+                            num_notify: 0,
+                            thread_mgmt_state: ThreadManagementState {
+                                shutdown: false,
+                                shutdown_tx: Some(shutdown_tx),
+                                last_exiting_thread: None,
+                                worker_threads: HashMap::new(),
+                                worker_thread_index: 0,
+                            },
+                        }),
+                        condvar: Condvar::new(),
                     }),
-                    condvar: Condvar::new(),
                     thread_name: builder.thread_name.clone(),
                     stack_size: builder.thread_stack_size,
                     after_start: builder.after_start.clone(),
@@ -242,23 +269,13 @@ impl BlockingPool {
     }
 
     pub(crate) fn shutdown(&mut self, timeout: Option<Duration>) {
-        let mut shared = self.spawner.inner.shared.lock();
-
         // The function can be called multiple times. First, by explicitly
         // calling `shutdown` then by the drop handler calling `shutdown`. This
         // prevents shutting down twice.
-        if shared.shutdown {
-            return;
-        }
-
-        shared.shutdown = true;
-        shared.shutdown_tx = None;
-        self.spawner.inner.condvar.notify_all();
-
-        let last_exited_thread = std::mem::take(&mut shared.last_exiting_thread);
-        let workers = std::mem::take(&mut shared.worker_threads);
-
-        drop(shared);
+        let (last_exited_thread, workers) = match self.spawner.inner.inner_impl.begin_shutdown() {
+            Some(x) => x,
+            None => return,
+        };
 
         if self.shutdown_rx.wait(timeout) {
             let _ = last_exited_thread.map(thread::JoinHandle::join);
@@ -391,38 +408,30 @@ impl Spawner {
     }
 
     fn spawn_task(&self, task: Task, rt: &Handle) -> Result<(), SpawnError> {
-        let mut shared = self.inner.shared.lock();
+        // The `on_no_idle` closure runs under the same lock as the queue
+        // push, exactly like the pre-refactor code that called
+        // `self.spawn_thread` directly while holding `Mutex<ThreadManagementState>`.
+        self.inner
+            .inner_impl
+            .spawn_task(task, &self.inner.metrics, |thread_mgmt_state| {
+                // No threads are able to process the task.
 
-        if shared.shutdown {
-            // Shutdown the task: it's fine to shutdown this task (even if
-            // mandatory) because it was scheduled after the shutdown of the
-            // runtime began.
-            task.task.shutdown();
+                if self.inner.metrics.num_threads() == self.inner.thread_cap {
+                    // At max number of threads
+                    return Ok(());
+                }
 
-            // no need to even push this task; it would never get picked up
-            return Err(SpawnError::ShuttingDown);
-        }
-
-        shared.queue.push_back(task);
-        self.inner.metrics.inc_queue_depth();
-
-        if self.inner.metrics.num_idle_threads() == 0 {
-            // No threads are able to process the task.
-
-            if self.inner.metrics.num_threads() == self.inner.thread_cap {
-                // At max number of threads
-            } else {
-                assert!(shared.shutdown_tx.is_some());
-                let shutdown_tx = shared.shutdown_tx.clone();
+                assert!(thread_mgmt_state.shutdown_tx.is_some());
+                let shutdown_tx = thread_mgmt_state.shutdown_tx.clone();
 
                 if let Some(shutdown_tx) = shutdown_tx {
-                    let id = shared.worker_thread_index;
+                    let id = thread_mgmt_state.worker_thread_index;
 
                     match self.spawn_thread(shutdown_tx, rt, id) {
                         Ok(handle) => {
                             self.inner.metrics.inc_num_threads();
-                            shared.worker_thread_index += 1;
-                            shared.worker_threads.insert(id, handle);
+                            thread_mgmt_state.worker_thread_index += 1;
+                            thread_mgmt_state.worker_threads.insert(id, handle);
                         }
                         Err(ref e)
                             if is_temporary_os_thread_error(e)
@@ -439,19 +448,9 @@ impl Spawner {
                         }
                     }
                 }
-            }
-        } else {
-            // Notify an idle worker thread. The notification counter
-            // is used to count the needed amount of notifications
-            // exactly. Thread libraries may generate spurious
-            // wakeups, this counter is used to keep us in a
-            // consistent state.
-            self.inner.metrics.dec_num_idle_threads();
-            shared.num_notify += 1;
-            self.inner.condvar.notify_one();
-        }
 
-        Ok(())
+                Ok(())
+            })
     }
 
     fn spawn_thread(
@@ -493,6 +492,216 @@ cfg_unstable_metrics! {
     }
 }
 
+// Each method on `InnerImpl` dispatches to the matching method on the
+// concrete variant. The variant methods own the entire critical section
+// for their operation, which makes it self-evident that the `Locked`
+// variant's behavior is identical to the pre-refactor code and gives a
+// future `Concurrent` variant a symmetric slot to fill.
+impl InnerImpl {
+    fn spawn_task<F>(
+        &self,
+        task: Task,
+        metrics: &SpawnerMetrics,
+        on_no_idle: F,
+    ) -> Result<(), SpawnError>
+    where
+        F: FnOnce(&mut ThreadManagementState) -> Result<(), SpawnError>,
+    {
+        match self {
+            InnerImpl::Locked(l) => l.spawn_task(task, metrics, on_no_idle),
+        }
+    }
+
+    fn run_worker(
+        &self,
+        metrics: &SpawnerMetrics,
+        keep_alive: Duration,
+        worker_thread_id: usize,
+    ) -> Option<thread::JoinHandle<()>> {
+        match self {
+            InnerImpl::Locked(l) => l.run_worker(metrics, keep_alive, worker_thread_id),
+        }
+    }
+
+    fn begin_shutdown(&self) -> Option<ShutdownHandles> {
+        match self {
+            InnerImpl::Locked(l) => l.begin_shutdown(),
+        }
+    }
+}
+
+// This is the original, single-lock implementation of the `spawn_blocking`
+// queue. Method scope was principally designed around ensuring that when the
+// code was refactored to enable adding a sharded queue implementation, this
+// was self-evidently behaviorally identical to the original implementation.
+impl LockedImpl {
+    /// Push a task and either notify an idle worker or invoke
+    /// `on_no_idle` (which is responsible for spawning a new worker if
+    /// possible).
+    fn spawn_task<F>(
+        &self,
+        task: Task,
+        metrics: &SpawnerMetrics,
+        on_no_idle: F,
+    ) -> Result<(), SpawnError>
+    where
+        F: FnOnce(&mut ThreadManagementState) -> Result<(), SpawnError>,
+    {
+        let mut locked = self.mutex.lock();
+
+        if locked.thread_mgmt_state.shutdown {
+            // Shutdown the task: it's fine to shutdown this task
+            // (even if mandatory) because it was scheduled after the
+            // shutdown of the runtime began.
+            task.task.shutdown();
+            return Err(SpawnError::ShuttingDown);
+        }
+
+        locked.queue.push_back(task);
+        metrics.inc_queue_depth();
+
+        if metrics.num_idle_threads() == 0 {
+            on_no_idle(&mut locked.thread_mgmt_state)?;
+        } else {
+            // Notify an idle worker thread. The notification counter
+            // is used to count the needed amount of notifications
+            // exactly. Thread libraries may generate spurious
+            // wakeups, this counter is used to keep us in a
+            // consistent state.
+            metrics.dec_num_idle_threads();
+            locked.num_notify += 1;
+            self.condvar.notify_one();
+        }
+
+        Ok(())
+    }
+
+    /// Run a worker thread's main loop.
+    fn run_worker(
+        &self,
+        metrics: &SpawnerMetrics,
+        keep_alive: Duration,
+        worker_thread_id: usize,
+    ) -> Option<thread::JoinHandle<()>> {
+        let mut locked = self.mutex.lock();
+        let mut join_on_thread = None;
+        // is this thread currently counted in `num_idle_threads`?
+        let mut is_counted_idle;
+
+        'main: loop {
+            // BUSY
+            while let Some(task) = locked.queue.pop_front() {
+                metrics.dec_queue_depth();
+                drop(locked);
+                task.run();
+
+                locked = self.mutex.lock();
+            }
+
+            // IDLE
+            metrics.inc_num_idle_threads();
+            // mark this thread as currently counted in `num_idle_threads`.
+            is_counted_idle = true;
+
+            while !locked.thread_mgmt_state.shutdown {
+                let lock_result = self.condvar.wait_timeout(locked, keep_alive).unwrap();
+
+                locked = lock_result.0;
+                let timeout_result = lock_result.1;
+
+                if locked.num_notify != 0 {
+                    // We have received a legitimate wakeup,
+                    // acknowledge it by decrementing the counter
+                    // and transition to the BUSY state.
+                    locked.num_notify -= 1;
+                    // since this is a legitimate wakeup,
+                    // the `Spawner::spawn_task` has already
+                    // decremented `num_idle_threads`.
+                    is_counted_idle = false;
+                    break;
+                }
+
+                // Even if the condvar "timed out", if the pool is
+                // entering the shutdown phase, we want to perform
+                // the cleanup logic.
+                if !locked.thread_mgmt_state.shutdown && timeout_result.timed_out() {
+                    // We'll join the prior timed-out thread's
+                    // JoinHandle after dropping the lock. This
+                    // isn't done when shutting down, because the
+                    // thread calling shutdown will handle joining
+                    // everything.
+                    let my_handle = locked
+                        .thread_mgmt_state
+                        .worker_threads
+                        .remove(&worker_thread_id);
+                    join_on_thread = std::mem::replace(
+                        &mut locked.thread_mgmt_state.last_exiting_thread,
+                        my_handle,
+                    );
+
+                    break 'main;
+                }
+
+                // Spurious wakeup detected, go back to sleep.
+            }
+
+            if locked.thread_mgmt_state.shutdown {
+                // Drain the queue
+                while let Some(task) = locked.queue.pop_front() {
+                    metrics.dec_queue_depth();
+                    drop(locked);
+
+                    task.shutdown_or_run_if_mandatory();
+
+                    locked = self.mutex.lock();
+                }
+
+                break;
+            }
+        }
+
+        // Thread exit
+        metrics.dec_num_threads();
+
+        // Is this thread currently counted in `num_idle_threads`?
+        if is_counted_idle {
+            // `num_idle_threads` should now be tracked exactly,
+            // panic with a descriptive message if it is not the
+            // case.
+            let prev_idle = metrics.dec_num_idle_threads();
+            assert_ne!(
+                prev_idle, 0,
+                "`num_idle_threads` underflowed on thread exit"
+            );
+        }
+
+        if locked.thread_mgmt_state.shutdown && metrics.num_threads() == 0 {
+            self.condvar.notify_one();
+        }
+
+        drop(locked);
+
+        join_on_thread
+    }
+
+    /// Begin pool shutdown: set the shutdown flag, drop the shutdown
+    /// sender, wake all waiting workers, and hand back the worker
+    /// `JoinHandle`s for the caller to join.
+    fn begin_shutdown(&self) -> Option<ShutdownHandles> {
+        let mut locked = self.mutex.lock();
+        if locked.thread_mgmt_state.shutdown {
+            return None;
+        }
+        locked.thread_mgmt_state.shutdown = true;
+        locked.thread_mgmt_state.shutdown_tx = None;
+        self.condvar.notify_all();
+
+        let last_exited_thread = std::mem::take(&mut locked.thread_mgmt_state.last_exiting_thread);
+        let workers = std::mem::take(&mut locked.thread_mgmt_state.worker_threads);
+        Some((last_exited_thread, workers))
+    }
+}
+
 // Tells whether the error when spawning a thread is temporary.
 #[inline]
 fn is_temporary_os_thread_error(error: &io::Error) -> bool {
@@ -505,93 +714,9 @@ impl Inner {
             f();
         }
 
-        let mut shared = self.shared.lock();
-        let mut join_on_thread = None;
-        // is this thread currently counted in `num_idle_threads`?
-        let mut is_counted_idle;
-
-        'main: loop {
-            // BUSY
-            while let Some(task) = shared.queue.pop_front() {
-                self.metrics.dec_queue_depth();
-                drop(shared);
-                task.run();
-
-                shared = self.shared.lock();
-            }
-
-            // IDLE
-            self.metrics.inc_num_idle_threads();
-            // mark this thread as currently counted in `num_idle_threads`.
-            is_counted_idle = true;
-
-            while !shared.shutdown {
-                let lock_result = self.condvar.wait_timeout(shared, self.keep_alive).unwrap();
-
-                shared = lock_result.0;
-                let timeout_result = lock_result.1;
-
-                if shared.num_notify != 0 {
-                    // We have received a legitimate wakeup,
-                    // acknowledge it by decrementing the counter
-                    // and transition to the BUSY state.
-                    shared.num_notify -= 1;
-                    // since this is a legitimate wakeup,
-                    // the `Spawner::spawn_task` has already decremented `num_idle_threads`.
-                    is_counted_idle = false;
-                    break;
-                }
-
-                // Even if the condvar "timed out", if the pool is entering the
-                // shutdown phase, we want to perform the cleanup logic.
-                if !shared.shutdown && timeout_result.timed_out() {
-                    // We'll join the prior timed-out thread's JoinHandle after dropping the lock.
-                    // This isn't done when shutting down, because the thread calling shutdown will
-                    // handle joining everything.
-                    let my_handle = shared.worker_threads.remove(&worker_thread_id);
-                    join_on_thread = std::mem::replace(&mut shared.last_exiting_thread, my_handle);
-
-                    break 'main;
-                }
-
-                // Spurious wakeup detected, go back to sleep.
-            }
-
-            if shared.shutdown {
-                // Drain the queue
-                while let Some(task) = shared.queue.pop_front() {
-                    self.metrics.dec_queue_depth();
-                    drop(shared);
-
-                    task.shutdown_or_run_if_mandatory();
-
-                    shared = self.shared.lock();
-                }
-
-                break;
-            }
-        }
-
-        // Thread exit
-        self.metrics.dec_num_threads();
-
-        // Is this thread currently counted in `num_idle_threads`?
-        if is_counted_idle {
-            // `num_idle_threads` should now be tracked exactly, panic
-            // with a descriptive message if it is not the
-            // case.
-            let prev_idle = self.metrics.dec_num_idle_threads();
-            assert_ne!(
-                prev_idle, 0,
-                "`num_idle_threads` underflowed on thread exit"
-            );
-        }
-
-        if shared.shutdown && self.metrics.num_threads() == 0 {
-            self.condvar.notify_one();
-        }
-
-        drop(shared);
+        let join_on_thread =
+            self.inner_impl
+                .run_worker(&self.metrics, self.keep_alive, worker_thread_id);
 
         if let Some(f) = &self.before_stop {
             f();

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1069,6 +1069,11 @@ impl Builder {
     /// });
     /// # }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I/O driver or other OS resources required by the
+    /// runtime cannot be initialized.
     pub fn build(&mut self) -> io::Result<Runtime> {
         match &self.kind {
             Kind::CurrentThread => self.build_current_thread_runtime(),
@@ -1100,6 +1105,11 @@ impl Builder {
     ///     println!("Hello from the Tokio runtime");
     /// });
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I/O driver or other OS resources required by the
+    /// runtime cannot be initialized.
     pub fn build_local(&mut self, _options: LocalOptions) -> io::Result<LocalRuntime> {
         match &self.kind {
             Kind::CurrentThread => self.build_current_thread_local_runtime(),

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1100,8 +1100,7 @@ impl Builder {
     ///     println!("Hello from the Tokio runtime");
     /// });
     /// ```
-    #[allow(unused_variables, unreachable_patterns)]
-    pub fn build_local(&mut self, options: LocalOptions) -> io::Result<LocalRuntime> {
+    pub fn build_local(&mut self, _options: LocalOptions) -> io::Result<LocalRuntime> {
         match &self.kind {
             Kind::CurrentThread => self.build_current_thread_local_runtime(),
             #[cfg(feature = "rt-multi-thread")]

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -139,6 +139,9 @@ pub struct Builder {
     pub(super) metrics_poll_count_histogram: HistogramBuilder,
 
     /// When true, enables task schedule latency instrumentation.
+    pub(super) track_task_schedule_latency: bool,
+
+    /// When true, enables the task schedule latency histogram.
     pub(super) metrics_schedule_latency_histogram_enabled: bool,
 
     /// Configures the task schedule latency histogram.
@@ -340,6 +343,8 @@ impl Builder {
             metrics_poll_count_histogram_enable: false,
 
             metrics_poll_count_histogram: HistogramBuilder::default(),
+
+            track_task_schedule_latency: false,
 
             metrics_schedule_latency_histogram_enabled: false,
 
@@ -914,6 +919,9 @@ impl Builder {
     /// [`tokio::spawn`](crate::spawn) can be called, and may result in this callback being
     /// invoked immediately.
     ///
+    /// When task schedule latency tracking is enabled, the latency is available
+    /// from `TaskMeta::schedule_latency`.
+    ///
     /// **Note**: This is an [unstable API][unstable]. The public API of this type
     /// may break in 1.x releases. See [the documentation on unstable
     /// features][unstable] for details.
@@ -960,6 +968,9 @@ impl Builder {
     /// `f` is called within the Tokio context, so functions like
     /// [`tokio::spawn`](crate::spawn) can be called, and may result in this callback being
     /// invoked immediately.
+    ///
+    /// When task schedule latency tracking is enabled, the latency is available
+    /// from `TaskMeta::schedule_latency`.
     ///
     /// **Note**: This is an [unstable API][unstable]. The public API of this type
     /// may break in 1.x releases. See [the documentation on unstable
@@ -1719,6 +1730,7 @@ impl Builder {
                 enable_eager_driver_handoff: false,
                 seed_generator: seed_generator_1,
                 metrics_poll_count_histogram: self.metrics_poll_count_histogram_builder(),
+                track_task_schedule_latency: self.track_task_schedule_latency,
                 metrics_schedule_latency_histogram: self
                     .metrics_schedule_latency_histogram_builder(),
             },
@@ -1871,6 +1883,46 @@ cfg_test_util! {
 
 cfg_schedule_latency! {
     impl Builder {
+        /// Enables tracking task schedule latency.
+        ///
+        /// Task schedule latency is measured from a task's most recent
+        /// transition to the scheduled state until immediately before it is
+        /// polled. Waking a task that is already scheduled does not reset the
+        /// measurement. Once enabled, the latency is available to task poll
+        /// hooks through [`TaskMeta::schedule_latency`].
+        ///
+        /// Task schedule latencies are not tracked by default as doing so
+        /// requires calling [`Instant::now()`] when a task is scheduled and
+        /// when it is polled, which could add measurable overhead.
+        ///
+        /// The [`enable_metrics_schedule_latency_histogram`] method also
+        /// enables tracking and records the latencies in a histogram.
+        ///
+        /// **This feature is only supported on 64-bit targets.**
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// # use tokio::runtime;
+        /// let runtime = runtime::Builder::new_current_thread()
+        ///     .track_task_schedule_latency()
+        ///     .on_before_task_poll(|meta| {
+        ///         if let Some(latency) = meta.schedule_latency() {
+        ///             println!("task schedule latency: {latency:?}");
+        ///         }
+        ///     })
+        ///     .build()
+        ///     .unwrap();
+        /// ```
+        ///
+        /// [`TaskMeta::schedule_latency`]: crate::runtime::TaskMeta::schedule_latency
+        /// [`Instant::now()`]: std::time::Instant::now
+        /// [`enable_metrics_schedule_latency_histogram`]: Builder::enable_metrics_schedule_latency_histogram
+        pub fn track_task_schedule_latency(&mut self) -> &mut Self {
+            self.track_task_schedule_latency = true;
+            self
+        }
+
         /// Enables tracking the distribution of task schedule latencies. Task
         /// schedule latency is the time between when a task is scheduled for
         /// execution and when it is polled.
@@ -1886,6 +1938,10 @@ cfg_schedule_latency! {
         /// This has an extremely low memory footprint, but may not provide enough granularity. For
         /// better granularity with low memory usage, use [`metrics_schedule_latency_histogram_configuration()`]
         /// to select [`LogHistogram`] instead.
+        ///
+        /// On the multi-thread runtime, each task polled from the LIFO slot is
+        /// recorded as a separate schedule-latency sample. Task poll hooks
+        /// receive the same per-task latency through [`TaskMeta::schedule_latency`].
         ///
         /// # Examples
         ///
@@ -1912,6 +1968,7 @@ cfg_schedule_latency! {
         /// [`LogHistogram`]: crate::runtime::LogHistogram
         /// [`metrics_schedule_latency_histogram_configuration()`]: Builder::metrics_schedule_latency_histogram_configuration
         pub fn enable_metrics_schedule_latency_histogram(&mut self) -> &mut Self {
+            self.track_task_schedule_latency = true;
             self.metrics_schedule_latency_histogram_enabled = true;
             self
         }
@@ -2041,6 +2098,7 @@ cfg_rt_multi_thread! {
                     enable_eager_driver_handoff: self.enable_eager_driver_handoff,
                     seed_generator: seed_generator_1,
                     metrics_poll_count_histogram: self.metrics_poll_count_histogram_builder(),
+                    track_task_schedule_latency: self.track_task_schedule_latency,
                     metrics_schedule_latency_histogram: self.metrics_schedule_latency_histogram_builder(),
                 },
                 self.timer_flavor,

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -48,7 +48,11 @@ pub(crate) struct Config {
     /// How to build poll time histograms
     pub(crate) metrics_poll_count_histogram: Option<crate::runtime::HistogramBuilder>,
 
+    /// Whether to track task schedule latency.
+    pub(crate) track_task_schedule_latency: bool,
+
     /// How to build schedule latency histograms
+    #[cfg_attr(not(feature = "schedule-latency"), allow(dead_code))]
     pub(crate) metrics_schedule_latency_histogram: Option<crate::runtime::HistogramBuilder>,
 
     #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -158,11 +158,11 @@ cfg_rt! {
     }
 
     pub(crate) fn set_current_task_id(id: Option<Id>) -> Option<Id> {
-        CONTEXT.try_with(|ctx| ctx.current_task_id.replace(id)).unwrap_or(None)
+        CONTEXT.try_with(|ctx| ctx.current_task_id.replace(id)).unwrap_or_default()
     }
 
     pub(crate) fn current_task_id() -> Option<Id> {
-        CONTEXT.try_with(|ctx| ctx.current_task_id.get()).unwrap_or(None)
+        CONTEXT.try_with(|ctx| ctx.current_task_id.get()).unwrap_or_default()
     }
 
     #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -200,7 +200,7 @@ impl ScheduledIo {
     /// the current value, returning the previous readiness value.
     ///
     /// # Arguments
-    /// - `tick`: whether setting the tick or trying to clear readiness for a
+    /// - `tick_op`: whether setting the tick or trying to clear readiness for a
     ///   specific tick.
     /// - `f`: a closure returning a new readiness value given the previous
     ///   readiness.

--- a/tokio/src/runtime/local_runtime/runtime.rs
+++ b/tokio/src/runtime/local_runtime/runtime.rs
@@ -86,6 +86,11 @@ impl LocalRuntime {
     /// // Use the runtime...
     /// ```
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the I/O driver or other OS resources required by the
+    /// runtime cannot be initialized.
+    ///
     /// [mod]: crate::runtime
     /// [runtime builder]: crate::runtime::Builder
     pub fn new() -> std::io::Result<LocalRuntime> {

--- a/tokio/src/runtime/metrics/batch.rs
+++ b/tokio/src/runtime/metrics/batch.rs
@@ -226,32 +226,95 @@ impl MetricsBatch {
     cfg_metrics_variant! {
         stable: {
             /// Start polling an individual task
-            pub(crate) fn start_poll(&mut self, _task_scheduled_at: Option<ScheduleLatencyContext>) {}
+            pub(crate) fn start_poll(
+                &mut self,
+                _schedule_latency_context: Option<ScheduleLatencyContext>,
+            ) -> Option<Duration> {
+                None
+            }
         },
         unstable: {
             /// Start polling an individual task
             ///
             /// # Arguments
             ///
-            /// `task_scheduled_at` is used to calculate task schedule latency.
-            /// A `ScheduleLatencyContext` can be obtained by calling `prepare` on a task's
-            /// `ScheduleLatencyInstant`.
-            pub(crate) fn start_poll(&mut self, _task_scheduled_at: Option<ScheduleLatencyContext>) {
+            /// `schedule_latency_context` is used to calculate task schedule latency.
+            pub(crate) fn start_poll(
+                &mut self,
+                schedule_latency_context: Option<ScheduleLatencyContext>,
+            ) -> Option<Duration> {
                 self.poll_count += 1;
-                if let Some(poll_timer) = &mut self.poll_timer {
-                    poll_timer.poll_started_at = Instant::now();
-                }
+                let poll_started_at = self.poll_timer.as_mut().map(|poll_timer| {
+                    let now = Instant::now();
+                    poll_timer.poll_started_at = now;
+                    now
+                });
+
                 #[cfg(feature = "schedule-latency")]
-                if let Some(task_scheduled_at) = _task_scheduled_at {
-                    if let Some(schedule_latencies) = &mut self.schedule_latencies {
-                        if let Some(now) = self.poll_timer.as_ref().map(|p| p.poll_started_at).or_else(now) {
-                            let elapsed = task_scheduled_at.elapsed_nanos(now);
-                            schedule_latencies.measure(elapsed, 1);
-                        }
-                    }
+                {
+                    self.record_schedule_latency_at(schedule_latency_context, poll_started_at)
+                }
+
+                #[cfg(not(feature = "schedule-latency"))]
+                {
+                    let _ = (poll_started_at, schedule_latency_context);
+                    None
                 }
             }
         }
+    }
+
+    cfg_metrics_variant! {
+        stable: {
+            /// Record the schedule latency of an additional task polled as part
+            /// of the current poll operation.
+            #[cfg(feature = "rt-multi-thread")]
+            pub(crate) fn record_schedule_latency(
+                &mut self,
+                _schedule_latency_context: Option<ScheduleLatencyContext>,
+            ) -> Option<Duration> {
+                None
+            }
+        },
+        unstable: {
+            /// Record the schedule latency of an additional task polled as part
+            /// of the current poll operation.
+            #[cfg(feature = "rt-multi-thread")]
+            pub(crate) fn record_schedule_latency(
+                &mut self,
+                schedule_latency_context: Option<ScheduleLatencyContext>,
+            ) -> Option<Duration> {
+                #[cfg(feature = "schedule-latency")]
+                {
+                    self.record_schedule_latency_at(schedule_latency_context, None)
+                }
+
+                #[cfg(not(feature = "schedule-latency"))]
+                {
+                    let _ = schedule_latency_context;
+                    None
+                }
+            }
+        }
+    }
+
+    #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
+    fn record_schedule_latency_at(
+        &mut self,
+        schedule_latency_context: Option<ScheduleLatencyContext>,
+        poll_started_at: Option<Instant>,
+    ) -> Option<Duration> {
+        let task_schedule_latency = schedule_latency_context.and_then(|schedule_latency_context| {
+            poll_started_at
+                .or_else(now)
+                .map(|now| Duration::from_nanos(schedule_latency_context.elapsed_nanos(now)))
+        });
+        if let (Some(task_schedule_latency), Some(schedule_latencies)) =
+            (task_schedule_latency, &mut self.schedule_latencies)
+        {
+            schedule_latencies.measure(duration_as_u64(task_schedule_latency), 1);
+        }
+        task_schedule_latency
     }
 
     cfg_metrics_variant! {

--- a/tokio/src/runtime/metrics/mod.rs
+++ b/tokio/src/runtime/metrics/mod.rs
@@ -41,10 +41,10 @@ cfg_not_unstable_metrics! {
 
 cfg_schedule_latency! {
     mod schedule_latency;
-    pub(crate) use schedule_latency::{ScheduleLatencyInstant, ScheduleLatencyContext};
+    pub(crate) use schedule_latency::{ScheduleLatencyContext, ScheduleLatencyInstant};
 }
 
 cfg_not_schedule_latency! {
     mod schedule_latency_mock;
-    pub(crate) use schedule_latency_mock::{ScheduleLatencyInstant, ScheduleLatencyContext};
+    pub(crate) use schedule_latency_mock::{ScheduleLatencyContext, ScheduleLatencyInstant};
 }

--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -474,8 +474,7 @@ impl RuntimeMetrics {
                 .worker_metrics(0)
                 .poll_count_histogram
                 .as_ref()
-                .map(|histogram| histogram.num_buckets())
-                .unwrap_or_default()
+                .map_or(0, |histogram| histogram.num_buckets())
         }
 
         /// Deprecated. Use [`poll_time_histogram_num_buckets()`] instead.
@@ -528,14 +527,13 @@ impl RuntimeMetrics {
                 .worker_metrics(0)
                 .poll_count_histogram
                 .as_ref()
-                .map(|histogram| {
+                .map_or_else(Range::default, |histogram| {
                     let range = histogram.bucket_range(bucket);
                     std::ops::Range {
                         start: Duration::from_nanos(range.start),
                         end: Duration::from_nanos(range.end),
                     }
                 })
-                .unwrap_or_default()
         }
 
         /// Deprecated. Use [`poll_time_histogram_bucket_range()`] instead.
@@ -977,8 +975,7 @@ impl RuntimeMetrics {
                 .worker_metrics(worker)
                 .poll_count_histogram
                 .as_ref()
-                .map(|histogram| histogram.get(bucket))
-                .unwrap_or_default()
+                .map_or(0, |histogram| histogram.get(bucket))
         }
 
         #[doc(hidden)]
@@ -1096,8 +1093,7 @@ impl RuntimeMetrics {
                 .worker_metrics(0)
                 .schedule_latency_histogram
                 .as_ref()
-                .map(|histogram| histogram.num_buckets())
-                .unwrap_or_default()
+                .map_or(0, |histogram| histogram.num_buckets())
         }
 
         /// Returns the range of task schedule latencies tracked by the given bucket.
@@ -1140,14 +1136,13 @@ impl RuntimeMetrics {
                 .worker_metrics(0)
                 .schedule_latency_histogram
                 .as_ref()
-                .map(|histogram| {
+                .map_or_else(Range::default, |histogram| {
                     let range = histogram.bucket_range(bucket);
                     std::ops::Range {
                         start: Duration::from_nanos(range.start),
                         end: Duration::from_nanos(range.end),
                     }
                 })
-                .unwrap_or_default()
         }
 
         /// Returns the number of times the given worker polled tasks with a schedule
@@ -1212,8 +1207,7 @@ impl RuntimeMetrics {
                 .worker_metrics(worker)
                 .schedule_latency_histogram
                 .as_ref()
-                .map(|histogram| histogram.get(bucket))
-                .unwrap_or_default()
+                .map_or(0, |histogram| histogram.get(bucket))
         }
     }
 
@@ -1303,8 +1297,7 @@ impl RuntimeMetrics {
                     .driver()
                     .io
                     .as_ref()
-                    .map(|h| f(&h.metrics))
-                    .unwrap_or(0)
+                    .map_or(0, |h| f(&h.metrics))
             }
     }
 }

--- a/tokio/src/runtime/metrics/schedule_latency.rs
+++ b/tokio/src/runtime/metrics/schedule_latency.rs
@@ -41,7 +41,7 @@ impl ScheduleLatencyInstant {
 /// `ScheduleLatencyContext` contains all the data required to calculate the time elapsed
 /// since a task was scheduled.
 ///
-/// `ScheduleLatencyInstant` on its own in insufficient because it only contains a delta.
+/// `ScheduleLatencyInstant` on its own is insufficient because it only contains a delta.
 /// The scheduler startup time is required to convert the delta back into an actual time
 /// but is omitted from `ScheduleLatencyInstant` to keep its memory size minimal.
 pub(crate) struct ScheduleLatencyContext {

--- a/tokio/src/runtime/metrics/schedule_latency_mock.rs
+++ b/tokio/src/runtime/metrics/schedule_latency_mock.rs
@@ -20,12 +20,3 @@ impl ScheduleLatencyInstant {
 pub(crate) struct ScheduleLatencyContext {
     _private: (),
 }
-
-impl ScheduleLatencyContext {
-    // This method is referenced (but never called) when the `schedule-latency`
-    // feature is disabled and `tokio_unstable` is enabled.
-    #[allow(dead_code)]
-    pub(crate) fn elapsed_nanos(&self, _now: Instant) -> u64 {
-        unimplemented!("This should never be called because prepare() always returns None")
-    }
-}

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -165,6 +165,11 @@ impl Runtime {
     /// // Use the runtime...
     /// ```
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the I/O driver or other OS resources required by the
+    /// runtime cannot be initialized.
+    ///
     /// [mod]: index.html
     /// [main]: ../attr.main.html
     /// [threaded scheduler]: index.html#threaded-scheduler

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -334,8 +334,6 @@ impl Runtime {
     /// });
     /// # }
     /// ```
-    ///
-    /// [handle]: fn@Handle::block_on
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         let fut_size = mem::size_of::<F>();

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -106,7 +106,7 @@ struct Shared {
     /// Startup time of this scheduler.
     ///
     /// This instant is used as the basis of task `scheduled_at` measurements.
-    started_at: Option<Instant>,
+    schedule_latency_start: Option<Instant>,
 }
 
 /// Thread-local context.
@@ -152,10 +152,7 @@ impl CurrentThread {
             .global_queue_interval
             .unwrap_or(DEFAULT_GLOBAL_QUEUE_INTERVAL);
 
-        let started_at = config
-            .metrics_schedule_latency_histogram
-            .as_ref()
-            .map(|_| Instant::now());
+        let schedule_latency_start = config.track_task_schedule_latency.then(Instant::now);
 
         let handle = Arc::new(Handle {
             name,
@@ -174,7 +171,7 @@ impl CurrentThread {
                 config,
                 scheduler_metrics: SchedulerMetrics::new(),
                 worker_metrics,
-                started_at,
+                schedule_latency_start,
             },
             driver: driver_handle,
             blocking_spawner,
@@ -382,13 +379,13 @@ impl Context {
     /// Execute the closure with the given scheduler core stored in the
     /// thread-local context.
     fn run_task(&self, task: LocalNotified<Arc<Handle>>, mut core: Box<Core>) -> Box<Core> {
-        #[cfg(tokio_unstable)]
-        let task_meta = task.task_meta();
+        let schedule_latency_context = task
+            .get_scheduled_at()
+            .prepare(self.handle.shared.schedule_latency_start);
+        let _task_schedule_latency = core.metrics.start_poll(schedule_latency_context);
 
-        core.metrics.start_poll(
-            task.get_scheduled_at()
-                .prepare(self.handle.shared.started_at),
-        );
+        #[cfg(tokio_unstable)]
+        let task_meta = task.task_meta(_task_schedule_latency);
 
         let (mut c, ()) = self.enter(core, || {
             crate::task::coop::budget(|| {
@@ -510,6 +507,8 @@ impl Handle {
         me.task_hooks.spawn(&TaskMeta {
             id,
             spawned_at,
+            #[cfg(feature = "schedule-latency")]
+            schedule_latency: None,
             _phantom: Default::default(),
         });
 
@@ -548,6 +547,8 @@ impl Handle {
         me.task_hooks.spawn(&TaskMeta {
             id,
             spawned_at,
+            #[cfg(feature = "schedule-latency")]
+            schedule_latency: None,
             _phantom: Default::default(),
         });
 
@@ -702,13 +703,10 @@ impl Schedule for Arc<Handle> {
     fn schedule(&self, task: task::Notified<Self>) {
         use scheduler::Context::CurrentThread;
 
-        if self
-            .shared
-            .config
-            .metrics_schedule_latency_histogram
-            .is_some()
-        {
-            task.set_scheduled_at(ScheduleLatencyInstant::new(self.shared.started_at));
+        if self.shared.schedule_latency_start.is_some() {
+            task.set_scheduled_at(ScheduleLatencyInstant::new(
+                self.shared.schedule_latency_start,
+            ));
         }
 
         context::with_scheduler(|maybe_cx| match maybe_cx {

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -385,8 +385,6 @@ impl Context {
             core = c;
         }
 
-        // If `before_park` spawns a task (or otherwise schedules work for us), then we should not
-        // park the thread.
         if !self.has_pending_work(&core) {
             // Park until the thread is signaled
             core.metrics.about_to_park();
@@ -396,6 +394,15 @@ impl Context {
 
             core.metrics.unparked();
             core.submit_metrics(handle);
+        } else {
+            // `before_park` scheduled work (e.g. an `on_thread_park` hook that woke the
+            // `block_on` future), so we don't block. We must still poll the driver once
+            // without blocking, or timer and I/O events would stall under a runtime driven
+            // by repeated short `block_on` calls. See
+            // <https://github.com/tokio-rs/tokio/issues/8212>.
+            core.submit_metrics(handle);
+
+            core = self.park_internal(core, handle, &mut driver, Some(Duration::from_millis(0)));
         }
 
         if let Some(f) = &handle.shared.config.after_unpark {

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -142,7 +142,7 @@ cfg_rt! {
         /// Returns true if this is a local runtime and the runtime is owned by the current thread.
         pub(crate) fn can_spawn_local_on_local_runtime(&self) -> bool {
             match self {
-                Handle::CurrentThread(h) => h.local_tid.map(|x| std::thread::current().id() == x).unwrap_or(false),
+                Handle::CurrentThread(h) => h.local_tid.is_some_and(|x| std::thread::current().id() == x),
 
                 #[cfg(feature = "rt-multi-thread")]
                 Handle::MultiThread(_) => false,

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -93,6 +93,8 @@ impl Handle {
         me.task_hooks.spawn(&TaskMeta {
             id,
             spawned_at,
+            #[cfg(feature = "schedule-latency")]
+            schedule_latency: None,
             _phantom: Default::default(),
         });
 

--- a/tokio/src/runtime/scheduler/multi_thread/stats.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/stats.rs
@@ -114,10 +114,21 @@ impl Stats {
         }
     }
 
-    pub(crate) fn start_poll(&mut self, task_scheduled_at: Option<ScheduleLatencyContext>) {
-        self.batch.start_poll(task_scheduled_at);
+    pub(crate) fn start_poll(
+        &mut self,
+        schedule_latency_context: Option<ScheduleLatencyContext>,
+    ) -> Option<Duration> {
+        let task_schedule_latency = self.batch.start_poll(schedule_latency_context);
 
         self.tasks_polled_in_batch += 1;
+        task_schedule_latency
+    }
+
+    pub(crate) fn record_schedule_latency(
+        &mut self,
+        schedule_latency_context: Option<ScheduleLatencyContext>,
+    ) -> Option<Duration> {
+        self.batch.record_schedule_latency(schedule_latency_context)
     }
 
     pub(crate) fn end_poll(&mut self) {

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -206,7 +206,7 @@ pub(crate) struct Shared {
     /// Startup time of this scheduler.
     ///
     /// This instant is used as the basis of task `scheduled_at` measurements.
-    started_at: Option<Instant>,
+    schedule_latency_start: Option<Instant>,
 
     /// Only held to trigger some code on drop. This is used to get internal
     /// runtime metrics that can be useful when doing performance
@@ -317,10 +317,7 @@ pub(super) fn create(
 
     let (idle, idle_synced) = Idle::new(size);
     let (inject, inject_synced) = inject::Shared::new();
-    let started_at = config
-        .metrics_schedule_latency_histogram
-        .as_ref()
-        .map(|_| Instant::now());
+    let schedule_latency_start = config.track_task_schedule_latency.then(Instant::now);
 
     let remotes_len = remotes.len();
     let handle = Arc::new(Handle {
@@ -342,7 +339,7 @@ pub(super) fn create(
             config,
             scheduler_metrics: SchedulerMetrics::new(),
             worker_metrics: worker_metrics.into_boxed_slice(),
-            started_at,
+            schedule_latency_start,
             _counters: Counters,
         },
         driver: driver_handle,
@@ -639,9 +636,6 @@ impl Context {
     }
 
     fn run_task(&self, task: Notified, mut core: Box<Core>) -> RunResult {
-        #[cfg(tokio_unstable)]
-        let task_meta = task.task_meta();
-
         let task = self.worker.handle.shared.owned.assert_owner(task);
 
         // Make sure the worker is not in the **searching** state. This enables
@@ -674,13 +668,16 @@ impl Context {
         self.assert_lifo_enabled_is_correct(&core);
 
         // Measure the poll start time. Note that we may end up polling other
-        // tasks under this measurement. In this case, the tasks came from the
-        // LIFO slot and are considered part of the current task for scheduling
-        // purposes. These tasks inherent the "parent"'s limits.
-        core.stats.start_poll(
-            task.get_scheduled_at()
-                .prepare(self.worker.handle.shared.started_at),
-        );
+        // tasks under this poll-time measurement. Tasks from the LIFO slot
+        // inherit the "parent"'s limits, but their schedule latency is recorded
+        // separately when each task is polled.
+        let schedule_latency_context = task
+            .get_scheduled_at()
+            .prepare(self.worker.handle.shared.schedule_latency_start);
+        let _task_schedule_latency = core.stats.start_poll(schedule_latency_context);
+
+        #[cfg(tokio_unstable)]
+        let task_meta = task.task_meta(_task_schedule_latency);
 
         // Make the core available to the runtime context
         *self.core.borrow_mut() = Some(core);
@@ -759,12 +756,21 @@ impl Context {
                     super::counters::inc_lifo_capped();
                 }
 
-                // Run the LIFO task, then loop
-                *self.core.borrow_mut() = Some(core);
                 let task = self.worker.handle.shared.owned.assert_owner(task);
 
+                // Record the LIFO task's schedule latency independently from
+                // the outer task's poll-time sample. The returned value is the
+                // same sample that is passed to the histogram recorder.
+                let schedule_latency_context = task
+                    .get_scheduled_at()
+                    .prepare(self.worker.handle.shared.schedule_latency_start);
+                let _task_schedule_latency =
+                    core.stats.record_schedule_latency(schedule_latency_context);
+
+                *self.core.borrow_mut() = Some(core);
+
                 #[cfg(tokio_unstable)]
-                let task_meta = task.task_meta();
+                let task_meta = task.task_meta(_task_schedule_latency);
 
                 #[cfg(tokio_unstable)]
                 self.worker
@@ -1339,13 +1345,10 @@ impl Worker {
 
 impl Handle {
     pub(super) fn schedule_task(&self, task: Notified, is_yield: bool) {
-        if self
-            .shared
-            .config
-            .metrics_schedule_latency_histogram
-            .is_some()
-        {
-            task.set_scheduled_at(ScheduleLatencyInstant::new(self.shared.started_at));
+        if self.shared.schedule_latency_start.is_some() {
+            task.set_scheduled_at(ScheduleLatencyInstant::new(
+                self.shared.schedule_latency_start,
+            ));
         }
 
         with_current(|maybe_cx| {

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -402,10 +402,32 @@ where
         }
     }
 
+    // Move the runtime to another thread, if there is one to move.
+    // Do this in a non-generic function that doesn't depend on `F` or `R`.
+    let (had_entered, take_core) = match maybe_move_runtime() {
+        Ok(r) => r,
+        Err(panic_message) => panic!("{}", panic_message),
+    };
+
+    if had_entered {
+        // Unset the current task's budget. Blocking sections are not
+        // constrained by task budgets.
+        let _reset = Reset {
+            take_core,
+            budget: coop::stop(),
+        };
+
+        crate::runtime::context::exit_runtime(f)
+    } else {
+        f()
+    }
+}
+
+fn maybe_move_runtime() -> Result<(bool, bool), &'static str> {
     let mut had_entered = false;
     let mut take_core = false;
 
-    let setup_result = with_current(|maybe_cx| {
+    with_current(|maybe_cx| {
         match (
             crate::runtime::context::current_enter_context(),
             maybe_cx.is_some(),
@@ -488,24 +510,8 @@ where
         let worker = cx.worker.clone();
         runtime::spawn_blocking(move || run(worker));
         Ok(())
-    });
-
-    if let Err(panic_message) = setup_result {
-        panic!("{}", panic_message);
-    }
-
-    if had_entered {
-        // Unset the current task's budget. Blocking sections are not
-        // constrained by task budgets.
-        let _reset = Reset {
-            take_core,
-            budget: coop::stop(),
-        };
-
-        crate::runtime::context::exit_runtime(f)
-    } else {
-        f()
-    }
+    })?;
+    Ok((had_entered, take_core))
 }
 
 impl Launch {

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -374,6 +374,8 @@ where
                 f(&TaskMeta {
                     id: self.core().task_id,
                     spawned_at: self.core().spawned_at.into(),
+                    #[cfg(feature = "schedule-latency")]
+                    schedule_latency: None,
                     _phantom: Default::default(),
                 })
             }));

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -226,6 +226,8 @@ use crate::runtime::TaskCallback;
 use std::marker::PhantomData;
 use std::panic::Location;
 use std::ptr::NonNull;
+#[cfg(tokio_unstable)]
+use std::time::Duration;
 use std::{fmt, mem};
 
 /// An owned handle to the task, tracked by ref count.
@@ -243,12 +245,6 @@ unsafe impl<S> Sync for Task<S> {}
 pub(crate) struct Notified<S: 'static>(Task<S>);
 
 impl<S> Notified<S> {
-    #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
-    #[inline]
-    pub(crate) fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
-        self.0.task_meta()
-    }
-
     pub(crate) fn set_scheduled_at(&self, scheduled_at: ScheduleLatencyInstant) {
         // SAFETY: There are no concurrent writes because there is only ever one `Notified`
         // reference per task. There are no concurrent reads because this field is only read
@@ -275,8 +271,11 @@ pub(crate) struct LocalNotified<S: 'static> {
 impl<S> LocalNotified<S> {
     #[cfg(tokio_unstable)]
     #[inline]
-    pub(crate) fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
-        self.task.task_meta()
+    pub(crate) fn task_meta<'meta>(
+        &self,
+        schedule_latency: Option<Duration>,
+    ) -> crate::runtime::TaskMeta<'meta> {
+        self.task.task_meta(schedule_latency)
     }
 
     pub(crate) fn get_scheduled_at(&self) -> ScheduleLatencyInstant {
@@ -448,10 +447,15 @@ impl<S: 'static> Task<S> {
     // the compiler infers the lifetimes to be the same, and considers the task
     // to be borrowed for the lifetime of the returned `TaskMeta`.
     #[cfg(tokio_unstable)]
-    pub(crate) fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
+    pub(crate) fn task_meta<'meta>(
+        &self,
+        _schedule_latency: Option<Duration>,
+    ) -> crate::runtime::TaskMeta<'meta> {
         crate::runtime::TaskMeta {
             id: self.id(),
             spawned_at: self.spawned_at().into(),
+            #[cfg(feature = "schedule-latency")]
+            schedule_latency: _schedule_latency,
             _phantom: PhantomData,
         }
     }

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -147,7 +147,9 @@ impl Context {
     pub(crate) fn is_tracing() -> bool {
         // SAFETY: This call can only access the trace_leaf_fn field, so it cannot break the trace
         // frame linked list.
-        unsafe { Self::try_with_current(|ctx| ctx.trace_leaf_fn.get().is_some()).unwrap_or(false) }
+        unsafe {
+            Self::try_with_current(|ctx| ctx.trace_leaf_fn.get().is_some()).unwrap_or_default()
+        }
     }
 }
 

--- a/tokio/src/runtime/task/trace/symbol.rs
+++ b/tokio/src/runtime/task/trace/symbol.rs
@@ -65,7 +65,8 @@ impl Eq for Symbol {}
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(name) = self.symbol.name() {
-            let name = name.to_string();
+            // Printing this using :# formatting omits crate disambiguators.
+            let name = format!("{name:#}");
             let name = if let Some((name, _)) = name.rsplit_once("::") {
                 name
             } else {

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -1,5 +1,7 @@
 use super::Config;
 use std::marker::PhantomData;
+#[cfg(feature = "schedule-latency")]
+use std::time::Duration;
 
 impl TaskHooks {
     pub(crate) fn spawn(&self, meta: &TaskMeta<'_>) {
@@ -62,6 +64,9 @@ pub struct TaskMeta<'a> {
     /// The location where the task was spawned.
     #[cfg_attr(not(tokio_unstable), allow(unreachable_pub, dead_code))]
     pub(crate) spawned_at: crate::runtime::task::SpawnLocation,
+    /// The latency between scheduling the task and starting its current poll.
+    #[cfg(feature = "schedule-latency")]
+    pub(crate) schedule_latency: Option<Duration>,
     pub(crate) _phantom: PhantomData<&'a ()>,
 }
 
@@ -76,6 +81,32 @@ impl<'a> TaskMeta<'a> {
     #[cfg(tokio_unstable)]
     pub fn spawned_at(&self) -> &'static std::panic::Location<'static> {
         self.spawned_at.0
+    }
+
+    /// Returns the latency between scheduling the task and starting its
+    /// current poll.
+    ///
+    /// Task schedule latency is measured from the task's most recent transition
+    /// to the scheduled state until immediately before the
+    /// [`on_before_task_poll`] callback. Waking a task that is already scheduled
+    /// does not reset the measurement.
+    ///
+    /// This returns `Some` from [`on_before_task_poll`] and
+    /// [`on_after_task_poll`] callbacks when tracking is enabled with
+    /// [`track_task_schedule_latency`] or
+    /// [`enable_metrics_schedule_latency_histogram`]. Both callbacks receive
+    /// the same value, so time spent polling the task is not included. It
+    /// returns `None` when tracking is disabled and from task spawn and
+    /// termination callbacks.
+    ///
+    /// [`track_task_schedule_latency`]: crate::runtime::Builder::track_task_schedule_latency
+    /// [`enable_metrics_schedule_latency_histogram`]: crate::runtime::Builder::enable_metrics_schedule_latency_histogram
+    /// [`on_before_task_poll`]: crate::runtime::Builder::on_before_task_poll
+    /// [`on_after_task_poll`]: crate::runtime::Builder::on_after_task_poll
+    #[cfg(feature = "schedule-latency")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "schedule-latency")))]
+    pub fn schedule_latency(&self) -> Option<Duration> {
+        self.schedule_latency
     }
 }
 

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -425,8 +425,7 @@ impl Handle {
                     Ok(when) => {
                         if lock
                             .next_wake
-                            .map(|next_wake| when < next_wake.get())
-                            .unwrap_or(true)
+                            .map_or(true, |next_wake| when < next_wake.get())
                         {
                             unpark.unpark();
                         }

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -105,8 +105,7 @@ impl Wheel {
         debug_assert!({
             self.levels[level]
                 .next_expiration(self.elapsed)
-                .map(|e| e.deadline >= self.elapsed)
-                .unwrap_or(true)
+                .map_or(true, |e| e.deadline >= self.elapsed)
         });
 
         Ok(when)

--- a/tokio/src/runtime/time_alt/entry.rs
+++ b/tokio/src/runtime/time_alt/entry.rs
@@ -210,12 +210,16 @@ impl Handle {
         }
     }
 
-    pub(crate) fn register_cancel_tx(&self, cancel_tx: Sender) {
+    /// Returns `false` if the `self` has already been cancelled or woken up.
+    pub(crate) fn register_cancel_tx(&self, cancel_tx: Sender) -> bool {
         let mut lock = self.entry.state.lock();
         if !lock.cancelled && !lock.woken_up {
             let old_tx = lock.cancel_tx.replace(cancel_tx);
             // don't unlock — poisoning the `Mutex` stops others from using the bad state.
             assert!(old_tx.is_none(), "cancel_tx is already registered");
+            true
+        } else {
+            false
         }
     }
 

--- a/tokio/src/runtime/time_alt/tests.rs
+++ b/tokio/src/runtime/time_alt/tests.rs
@@ -12,8 +12,12 @@ const NUM_ITEMS: usize = 16;
 const NUM_ITEMS: usize = 64;
 
 fn new_handle() -> (EntryHandle, AwokenCount) {
+    new_handle_with_deadline(0)
+}
+
+fn new_handle_with_deadline(deadline: u64) -> (EntryHandle, AwokenCount) {
     let (waker, count) = new_count_waker();
-    let entry = EntryHandle::new(0);
+    let entry = EntryHandle::new(deadline);
     _ = entry.poll(&mut Context::from_waker(&waker));
     (entry, count)
 }
@@ -66,7 +70,7 @@ fn cancel_in_the_same_thread() {
 
         for _ in 0..NUM_ITEMS {
             let (hdl, count) = new_handle();
-            hdl.register_cancel_tx(cancel_tx.clone());
+            assert!(hdl.register_cancel_tx(cancel_tx.clone()));
             counts.push(count);
             unsafe {
                 reg_queue.push_front(hdl.clone());
@@ -88,6 +92,97 @@ fn cancel_in_the_same_thread() {
         wake_queue.wake_all();
 
         assert!(counts.into_iter().all(|c| c.get() == 0));
+    });
+}
+
+#[test]
+fn insert_of_already_cancelled_entry_does_not_enter_wheel() {
+    let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
+    let mut wheel = Wheel::new();
+
+    // do not expire during the test
+    let far_future = 10_000_000;
+    let (hdl, awoken_count) = new_handle_with_deadline(far_future);
+
+    // cancel the timer before inserting it into the wheel
+    hdl.cancel();
+    assert!(hdl.is_cancelled());
+
+    // try to insert the cancelled entry into the wheel
+    unsafe {
+        wheel.insert(hdl, cancel_tx);
+    }
+
+    // a cancelled entry should not be inserted into the wheel
+    assert!(
+        wheel.next_expiration_time().is_none(),
+        "an already-cancelled entry leaked into the wheel on insert"
+    );
+
+    // It also must not have been queued for cancellation removal, since
+    // it was never actually placed in the wheel for `remove` to find.
+    assert_eq!(cancel_rx.recv_all().count(), 0);
+    assert_eq!(awoken_count.get(), 0);
+
+    // drain the wheel unconditionally, otherwise loom will complain
+    // about the leaked entry, which confuses developers in case
+    // this test fails for some other reason.
+    let mut wake_queue = WakeQueue::new();
+    wheel.take_expired(u64::MAX, &mut wake_queue);
+    wake_queue.wake_all();
+}
+
+#[test]
+fn cancel_races_with_insert() {
+    model(|| {
+        let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
+        let mut wheel = Wheel::new();
+
+        // do not expire during the test
+        let far_future = 10_000_000;
+        let (hdl, count) = new_handle_with_deadline(far_future);
+
+        let hdl2 = hdl.clone();
+        let jh = thread::spawn(move || {
+            // cancel the timer concurrently with insertion into the wheel
+            hdl2.cancel();
+        });
+
+        // try to insert the entry into the wheel concurrently with cancellation
+        unsafe {
+            wheel.insert(hdl, cancel_tx);
+        }
+
+        // ensure the cancellation thread has exited
+        jh.join().unwrap();
+
+        // Whichever way the race went, the entry must end up in exactly one
+        // of two consistent end states -- never "in the wheel with no way
+        // to ever remove it again":
+        //
+        // (a) `cancel()` won the race and ran first: `insert` sees it's
+        //     already cancelled and refuses to add it to the wheel.
+        // (b) `insert` won the race and registered `cancel_tx` first:
+        //     `cancel()` then finds `cancel_tx` and pushes the entry into
+        //     the cancellation queue for later removal from the wheel.
+        //
+        // Either way, the entry is not left stuck in the wheel with no
+        // corresponding entry in the cancellation queue.
+        let cancelled_via_queue = cancel_rx.recv_all().count();
+        let leaked_in_wheel = wheel.next_expiration_time().is_some();
+
+        assert!(
+            !leaked_in_wheel || cancelled_via_queue == 1,
+            "entry is stuck in the wheel with no way to ever be removed"
+        );
+        assert_eq!(count.get(), 0, "a cancelled entry must never be woken");
+
+        // drain the wheel unconditionally, otherwise loom will complain
+        // about the leaked entry, which confuses developers in case
+        // this test fails for some other reason.
+        let mut wake_queue = WakeQueue::new();
+        wheel.take_expired(u64::MAX, &mut wake_queue);
+        wake_queue.wake_all();
     });
 }
 
@@ -137,7 +232,7 @@ fn cancel_in_the_different_thread() {
 
         for _ in 0..NUM_ITEMS {
             let (hdl, count) = new_handle();
-            hdl.register_cancel_tx(cancel_tx.clone());
+            assert!(hdl.register_cancel_tx(cancel_tx.clone()));
             counts.push(count);
             hdls.push(hdl.clone());
             unsafe {

--- a/tokio/src/runtime/time_alt/tests.rs
+++ b/tokio/src/runtime/time_alt/tests.rs
@@ -97,39 +97,41 @@ fn cancel_in_the_same_thread() {
 
 #[test]
 fn insert_of_already_cancelled_entry_does_not_enter_wheel() {
-    let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
-    let mut wheel = Wheel::new();
+    model(|| {
+        let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
+        let mut wheel = Wheel::new();
 
-    // do not expire during the test
-    let far_future = 10_000_000;
-    let (hdl, awoken_count) = new_handle_with_deadline(far_future);
+        // do not expire during the test
+        let far_future = 10_000_000;
+        let (hdl, awoken_count) = new_handle_with_deadline(far_future);
 
-    // cancel the timer before inserting it into the wheel
-    hdl.cancel();
-    assert!(hdl.is_cancelled());
+        // cancel the timer before inserting it into the wheel
+        hdl.cancel();
+        assert!(hdl.is_cancelled());
 
-    // try to insert the cancelled entry into the wheel
-    unsafe {
-        wheel.insert(hdl, cancel_tx);
-    }
+        // try to insert the cancelled entry into the wheel
+        unsafe {
+            wheel.insert(hdl, cancel_tx);
+        }
 
-    // a cancelled entry should not be inserted into the wheel
-    assert!(
-        wheel.next_expiration_time().is_none(),
-        "an already-cancelled entry leaked into the wheel on insert"
-    );
+        // a cancelled entry should not be inserted into the wheel
+        assert!(
+            wheel.next_expiration_time().is_none(),
+            "an already-cancelled entry leaked into the wheel on insert"
+        );
 
-    // It also must not have been queued for cancellation removal, since
-    // it was never actually placed in the wheel for `remove` to find.
-    assert_eq!(cancel_rx.recv_all().count(), 0);
-    assert_eq!(awoken_count.get(), 0);
+        // It also must not have been queued for cancellation removal, since
+        // it was never actually placed in the wheel for `remove` to find.
+        assert_eq!(cancel_rx.recv_all().count(), 0);
+        assert_eq!(awoken_count.get(), 0);
 
-    // drain the wheel unconditionally, otherwise loom will complain
-    // about the leaked entry, which confuses developers in case
-    // this test fails for some other reason.
-    let mut wake_queue = WakeQueue::new();
-    wheel.take_expired(u64::MAX, &mut wake_queue);
-    wake_queue.wake_all();
+        // drain the wheel unconditionally, otherwise loom will complain
+        // about the leaked entry, which confuses developers in case
+        // this test fails for some other reason.
+        let mut wake_queue = WakeQueue::new();
+        wheel.take_expired(u64::MAX, &mut wake_queue);
+        wake_queue.wake_all();
+    });
 }
 
 #[test]

--- a/tokio/src/runtime/time_alt/wheel/mod.rs
+++ b/tokio/src/runtime/time_alt/wheel/mod.rs
@@ -54,7 +54,7 @@ impl Wheel {
         self.elapsed
     }
 
-    /// Inserts an entry into the timing wheel.
+    /// Inserts an entry into the timing wheel
     ///
     /// # Arguments
     ///
@@ -70,7 +70,10 @@ impl Wheel {
 
         assert!(deadline > self.elapsed);
 
-        hdl.register_cancel_tx(cancel_tx);
+        if !hdl.register_cancel_tx(cancel_tx) {
+            // `hdl` has been cancelled or woken up concurrently
+            return;
+        }
 
         // Get the level at which the entry should be stored
         let level = self.level_for(deadline);

--- a/tokio/src/runtime/time_alt/wheel/mod.rs
+++ b/tokio/src/runtime/time_alt/wheel/mod.rs
@@ -84,8 +84,7 @@ impl Wheel {
         debug_assert!({
             self.levels[level]
                 .next_expiration(self.elapsed)
-                .map(|e| e.deadline >= self.elapsed)
-                .unwrap_or(true)
+                .map_or(true, |e| e.deadline >= self.elapsed)
         });
     }
 

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -57,15 +57,20 @@ pub(super) fn ctrl_shutdown() -> io::Result<RxFuture> {
 }
 
 fn new(signal: SignalKind) -> io::Result<RxFuture> {
-    let registry = REGISTRY
+    // Initialize the registry BEFORE registering the OS handler: the
+    // handler thread can then always observe an initialized `REGISTRY`
+    // (`SetConsoleCtrlHandler` happens-after the initialization below),
+    // so it needs no blocking wait.
+    let registry = REGISTRY.get_or_init(Registry::default);
+
+    HANDLER_RESULT
         .get_or_init(
             || match unsafe { console::SetConsoleCtrlHandler(Some(handler), 1) } {
                 0 => Err(Error::last_os_error().raw_os_error().expect("unreachable")),
-                _ => Ok(Registry::default()),
+                _ => Ok(()),
             },
         )
-        .as_ref()
-        .map_err(|&code| Error::from_raw_os_error(code))?;
+        .map_err(Error::from_raw_os_error)?;
 
     let rx = registry[signal].subscribe();
     Ok(RxFuture::new(rx))
@@ -94,7 +99,11 @@ impl Index<SignalKind> for Registry {
     }
 }
 
-static REGISTRY: OnceLock<Result<Registry, i32>> = OnceLock::new();
+static REGISTRY: OnceLock<Registry> = OnceLock::new();
+
+/// Whether `SetConsoleCtrlHandler` succeeded, initialized (once) only
+/// after `REGISTRY` — see `new` for the ordering argument.
+static HANDLER_RESULT: OnceLock<Result<(), i32>> = OnceLock::new();
 
 unsafe extern "system" fn handler(ty: u32) -> BOOL {
     let signal = match ty {
@@ -107,11 +116,13 @@ unsafe extern "system" fn handler(ty: u32) -> BOOL {
         _ => return 0,
     };
 
-    // Note that `OnceLock::get` does not handle the small window between calling
-    // `SetConsoleCtrlHandler` and `REGISTRY` being initialized.
-    let Ok(registry) = REGISTRY.wait().as_ref() else {
-        // Technically unreachable since `handler` is only called if
-        // `SetConsoleCtrlHandler` succeeded.
+    // `new` initializes `REGISTRY` before it registers this handler with
+    // the OS, so an invoked handler always finds it initialized —
+    // `get()` suffices and no blocking wait is needed (using `get`
+    // also keeps the crate's MSRV: `OnceLock::wait` needs Rust 1.86).
+    let Some(registry) = REGISTRY.get() else {
+        // Unreachable by the ordering above; kept as a defensive
+        // fallback that lets the OS run the next handler.
         return 0;
     };
 

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -26,6 +26,35 @@ use std::sync::Arc;
 /// To use the `Semaphore` in a poll function, you can use the [`PollSemaphore`]
 /// utility.
 ///
+/// # Memory ordering
+///
+/// If a task writes some data and then releases a permit, any task that later
+/// acquires a permit is guaranteed to see that data. This makes it safe to use
+/// a semaphore to hand data off between tasks through shared state.
+///
+/// Stated more precisely in terms of atomic memory orderings: acquiring a
+/// permit (via [`acquire`], [`acquire_many`], [`try_acquire`],
+/// [`try_acquire_many`], or their `_owned` variants), releasing permits (by
+/// dropping a [`SemaphorePermit`] or [`OwnedSemaphorePermit`], or by calling
+/// [`add_permits`] or [`forget_permits`]), and closing the semaphore (via
+/// [`close`]) are all `AcqRel` operations. They are totally ordered, and each
+/// one synchronizes-with all such operations that precede it, giving the same
+/// guarantees as `AcqRel` operations on a single atomic.
+///
+/// A failed acquisition attempt (including [`TryAcquireError::NoPermits`] and
+/// [`TryAcquireError::Closed`]), along with the [`available_permits`] and
+/// [`is_closed`] methods, behave like an `Acquire` load.
+///
+/// [`acquire`]: Semaphore::acquire
+/// [`acquire_many`]: Semaphore::acquire_many
+/// [`try_acquire`]: Semaphore::try_acquire
+/// [`try_acquire_many`]: Semaphore::try_acquire_many
+/// [`add_permits`]: Semaphore::add_permits
+/// [`forget_permits`]: Semaphore::forget_permits
+/// [`close`]: Semaphore::close
+/// [`available_permits`]: Semaphore::available_permits
+/// [`is_closed`]: Semaphore::is_closed
+///
 /// # Examples
 ///
 /// Basic usage:

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -390,7 +390,6 @@ cfg_rt! {
     /// [`LocalSet`]: struct@crate::task::LocalSet
     /// [`LocalRuntime`]: struct@crate::runtime::LocalRuntime
     /// [`tokio::spawn`]: fn@crate::task::spawn
-    /// [unstable]: ../../tokio/index.html#unstable-features
     #[track_caller]
     pub fn spawn_local<F>(future: F) -> JoinHandle<F::Output>
     where

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -1266,9 +1266,7 @@ impl LocalState {
             // if we couldn't get the thread ID because we're dropping the local
             // data, skip the assertion --- the `Drop` impl is not going to be
             // called from another thread, because `LocalSet` is `!Send`
-            context::thread_id()
-                .map(|id| id == self.owner)
-                .unwrap_or(true),
+            context::thread_id().map_or(true, |id| id == self.owner),
             "`LocalSet`'s local run queue must not be accessed by another thread!"
         );
     }

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -769,8 +769,7 @@ mod unix_asyncfd {
     async_assert_fn!(AsyncFd<ImplsFd<NN>>::writable_mut(_): !Send & !Sync & !Unpin);
 }
 
-#[cfg(tokio_unstable)]
-mod unstable {
+mod local_runtime {
     use super::*;
 
     assert_value!(tokio::runtime::LocalRuntime: !Send & !Sync & Unpin);

--- a/tokio/tests/io_mem_stream.rs
+++ b/tokio/tests/io_mem_stream.rs
@@ -1,6 +1,8 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
+use futures::FutureExt;
+use std::io::IoSlice;
 use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt};
 
 #[tokio::test]
@@ -99,6 +101,38 @@ async fn max_write_size() {
 
     // drop b only after task t1 finishes writing
     drop(b);
+}
+
+#[tokio::test]
+async fn zero_length_operations() {
+    let (mut reader, _peer) = duplex(1);
+    assert!(matches!(reader.read(&mut []).now_or_never(), Some(Ok(0))));
+
+    let (mut writer, _peer) = duplex(1);
+    writer.write_all(b"x").await.unwrap();
+    assert!(matches!(writer.write(&[]).now_or_never(), Some(Ok(0))));
+
+    let (mut writer, _peer) = duplex(1);
+    writer.write_all(b"x").await.unwrap();
+    let bufs = [IoSlice::new(&[]), IoSlice::new(&[])];
+    assert!(matches!(
+        writer.write_vectored(&bufs).now_or_never(),
+        Some(Ok(0))
+    ));
+}
+
+#[tokio::test]
+async fn zero_length_writes_to_closed_stream() {
+    let (mut writer, peer) = duplex(1);
+    drop(peer);
+    let err = writer.write(&[]).await.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
+
+    let (mut writer, peer) = duplex(1);
+    drop(peer);
+    let bufs = [IoSlice::new(&[]), IoSlice::new(&[])];
+    let err = writer.write_vectored(&bufs).await.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
 }
 
 #[tokio::test]

--- a/tokio/tests/rt_common_before_park.rs
+++ b/tokio/tests/rt_common_before_park.rs
@@ -4,6 +4,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::runtime::Builder;
 use tokio::sync::Notify;
 
@@ -89,4 +90,53 @@ fn wake_from_other_thread_block_on() {
     });
 
     th.join().unwrap();
+}
+
+// Regression test for #8212: a current-thread runtime driven by repeated short
+// `block_on` calls, where `on_thread_park` wakes the `block_on` future, must
+// still drive the time driver so a spawned timer keeps making progress. Before
+// the fix, `before_park` setting the `woken` flag caused `park` to skip the
+// driver entirely, so the timer never fired.
+#[test]
+fn before_park_does_not_stall_spawned_timer() {
+    let notify = Arc::new(Notify::new());
+    let task_done = Arc::new(AtomicBool::new(false));
+
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .on_thread_park({
+            let notify = notify.clone();
+            move || notify.notify_waiters()
+        })
+        .build()
+        .unwrap();
+
+    rt.spawn({
+        let task_done = task_done.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            task_done.store(true, Ordering::SeqCst);
+        }
+    });
+
+    // A current-thread runtime only runs tasks while inside `block_on`, so drive it
+    // once to let the spawned task register its timer.
+    rt.block_on(tokio::task::yield_now());
+
+    // Drive the runtime in short bursts, the way an external event loop would. Each
+    // burst parks via `on_thread_park` (which wakes the `block_on` future); the fix
+    // keeps polling the driver so the spawned timer still fires. A regression stalls
+    // the timer, failing the assert below instead of hanging.
+    for _ in 0..100 {
+        if task_done.load(Ordering::SeqCst) {
+            break;
+        }
+        rt.block_on(notify.notified());
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    assert!(
+        task_done.load(Ordering::SeqCst),
+        "spawned task's timer never fired (issue #8212)"
+    );
 }

--- a/tokio/tests/rt_local.rs
+++ b/tokio/tests/rt_local.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", tokio_unstable))]
+#![cfg(feature = "full")]
 
 use std::panic;
 use tokio::runtime::LocalOptions;
@@ -118,25 +118,25 @@ fn test_spawn_local_from_guard_other_thread() {
 // the task would belong.
 // The test creates a `LocalRuntime` and `LocalSet`, drives the `LocalSet` on the `LocalRuntime`'s thread,
 // then spawns a **separate OS thread** and tries to call
-// `tokio::task::spawn_local` there. `std::panic::catch_unwind` is then used
-// to capture the panic and to assert that it indeed occurs.
+// `tokio::task::spawn_local` there.
 #[test]
+#[should_panic = "`spawn_local` called from outside of a `task::LocalSet` or `runtime::LocalRuntime`"]
 #[cfg_attr(target_family = "wasm", ignore)] // threads not supported
 fn test_spawn_local_panic() {
     let rt = rt();
     let local = LocalSet::new();
 
     rt.block_on(local.run_until(async {
-        let thread_result = std::thread::spawn(|| {
-            let panic_result = panic::catch_unwind(|| {
-                let _jh = tokio::task::spawn_local(async {
-                    println!("you will never see this line");
-                });
+        let panic = std::thread::spawn(|| {
+            let _jh = tokio::task::spawn_local(async {
+                println!("you will never see this line");
             });
-            assert!(panic_result.is_err(), "Expected panic, but none occurred");
         })
-        .join();
-        assert!(thread_result.is_ok(), "Thread itself panicked unexpectedly");
+        .join()
+        .unwrap_err();
+
+        // When panic=unwind
+        panic::resume_unwind(panic);
     }));
 }
 

--- a/tokio/tests/rt_unstable_metrics.rs
+++ b/tokio/tests/rt_unstable_metrics.rs
@@ -849,6 +849,57 @@ fn schedule_latency_counts() {
     }
 }
 
+#[cfg(feature = "schedule-latency")]
+#[test]
+fn schedule_latency_lifo_polls_are_recorded_individually() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_metrics_schedule_latency_histogram()
+        .enable_metrics_poll_time_histogram()
+        .metrics_schedule_latency_histogram_configuration(HistogramConfiguration::linear(
+            Duration::from_millis(10),
+            3,
+        ))
+        .build()
+        .unwrap();
+    let metrics = rt.metrics();
+
+    rt.block_on(async {
+        tokio::spawn(async {
+            drop(tokio::spawn(async {}));
+            wait_for_elapsed(Duration::from_millis(50));
+        })
+        .await
+        .unwrap();
+    });
+    drop(rt);
+
+    let bucket_counts = (0..metrics.schedule_latency_histogram_num_buckets())
+        .map(|bucket| metrics.schedule_latency_histogram_bucket_count(0, bucket))
+        .collect::<Vec<_>>();
+
+    assert_eq!(bucket_counts.iter().sum::<u64>(), 2);
+    assert!(bucket_counts.last().is_some_and(|count| *count >= 1));
+
+    assert_eq!(metrics.worker_poll_count(0), 1);
+    let poll_time_samples = (0..metrics.poll_time_histogram_num_buckets())
+        .map(|bucket| metrics.poll_time_histogram_bucket_count(0, bucket))
+        .sum::<u64>();
+    assert_eq!(poll_time_samples, 1);
+}
+
+#[cfg(feature = "schedule-latency")]
+fn wait_for_elapsed(duration: Duration) {
+    let start = std::time::Instant::now();
+    loop {
+        let elapsed = start.elapsed();
+        if elapsed >= duration {
+            return;
+        }
+        std::thread::sleep(duration - elapsed);
+    }
+}
+
 async fn try_spawn_stealable_task() -> Result<(), mpsc::RecvTimeoutError> {
     // We use a blocking channel to synchronize the tasks.
     let (tx, rx) = mpsc::channel();

--- a/tokio/tests/task_hooks.rs
+++ b/tokio/tests/task_hooks.rs
@@ -4,6 +4,8 @@
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+#[cfg(feature = "schedule-latency")]
+use std::time::{Duration, Instant};
 
 use tokio::runtime::Builder;
 
@@ -20,6 +22,8 @@ fn spawn_task_hook_fires() {
 
     let runtime = Builder::new_current_thread()
         .on_task_spawn(move |data| {
+            #[cfg(feature = "schedule-latency")]
+            assert_eq!(data.schedule_latency(), None);
             ids2.lock().unwrap().insert(data.id());
 
             count2.fetch_add(1, Ordering::SeqCst);
@@ -53,6 +57,8 @@ fn terminate_task_hook_fires() {
 
     let runtime = Builder::new_current_thread()
         .on_task_terminate(move |_data| {
+            #[cfg(feature = "schedule-latency")]
+            assert_eq!(_data.schedule_latency(), None);
             count2.fetch_add(1, Ordering::SeqCst);
         })
         .build()
@@ -172,6 +178,172 @@ fn task_hook_spawn_location_multi_thread() {
     let poll_starts = poll_starts.fetch_add(0, Ordering::SeqCst);
     assert!(poll_starts > 2);
     assert_eq!(poll_starts, poll_ends.fetch_add(0, Ordering::SeqCst));
+}
+
+#[cfg(feature = "schedule-latency")]
+#[test]
+fn task_hook_schedule_latency_non_poll_callbacks() {
+    let spawn_count = Arc::new(AtomicUsize::new(0));
+    let spawn_count2 = Arc::clone(&spawn_count);
+    let terminate_count = Arc::new(AtomicUsize::new(0));
+    let terminate_count2 = Arc::clone(&terminate_count);
+
+    let runtime = Builder::new_current_thread()
+        .track_task_schedule_latency()
+        .on_task_spawn(move |data| {
+            assert_eq!(data.schedule_latency(), None);
+            spawn_count2.fetch_add(1, Ordering::SeqCst);
+        })
+        .on_task_terminate(move |data| {
+            assert_eq!(data.schedule_latency(), None);
+            terminate_count2.fetch_add(1, Ordering::SeqCst);
+        })
+        .build()
+        .unwrap();
+
+    runtime.block_on(runtime.spawn(async {})).unwrap();
+    assert_eq!(spawn_count.load(Ordering::SeqCst), 1);
+    assert_eq!(terminate_count.load(Ordering::SeqCst), 1);
+}
+
+#[cfg(feature = "schedule-latency")]
+#[test]
+fn task_hook_schedule_latency_disabled() {
+    let runtime = Builder::new_current_thread()
+        .on_before_task_poll(|data| assert_eq!(data.schedule_latency(), None))
+        .build()
+        .unwrap();
+
+    runtime.block_on(runtime.spawn(async {})).unwrap();
+}
+
+#[cfg(feature = "schedule-latency")]
+#[test]
+fn task_hook_schedule_latency_current_thread() {
+    let target = Arc::new(Mutex::new(None));
+    let latencies = Arc::new(Mutex::new(Vec::new()));
+
+    let after_latencies = Arc::new(Mutex::new(Vec::new()));
+
+    let runtime = Builder::new_current_thread()
+        .enable_metrics_schedule_latency_histogram()
+        .on_before_task_poll(schedule_latency_hook(&target, &latencies))
+        .on_after_task_poll(schedule_latency_hook(&target, &after_latencies))
+        .build()
+        .unwrap();
+
+    let task = runtime.spawn(async {});
+    *target.lock().unwrap() = Some(task.id());
+
+    // A current-thread runtime has no background worker, so the spawned task
+    // cannot be polled until `block_on` starts driving the runtime below.
+    wait_for_elapsed(Duration::from_millis(50));
+    runtime.block_on(task).unwrap();
+
+    let latencies = latencies.lock().unwrap();
+    assert_eq!(latencies.len(), 1);
+    assert!(latencies[0] >= Duration::from_millis(25));
+    assert_eq!(*latencies, *after_latencies.lock().unwrap());
+}
+
+#[cfg(feature = "schedule-latency")]
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "WASI does not support multi-threaded runtime"
+)]
+#[test]
+fn task_hook_schedule_latency_multi_thread() {
+    let target = Arc::new(Mutex::new(None));
+    let latencies = Arc::new(Mutex::new(Vec::new()));
+
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(1)
+        .track_task_schedule_latency()
+        .on_before_task_poll(schedule_latency_hook(&target, &latencies))
+        .build()
+        .unwrap();
+
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let blocker = runtime.spawn(async move {
+        started_tx.send(()).unwrap();
+        release_rx.recv().unwrap();
+    });
+    started_rx.recv().unwrap();
+
+    let task = runtime.spawn(async {});
+    *target.lock().unwrap() = Some(task.id());
+
+    wait_for_elapsed(Duration::from_millis(50));
+    release_tx.send(()).unwrap();
+    runtime.block_on(async {
+        blocker.await.unwrap();
+        task.await.unwrap();
+    });
+
+    let latencies = latencies.lock().unwrap();
+    assert_eq!(latencies.len(), 1);
+    assert!(latencies[0] >= Duration::from_millis(25));
+}
+
+#[cfg(feature = "schedule-latency")]
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "WASI does not support multi-threaded runtime"
+)]
+#[test]
+fn task_hook_schedule_latency_multi_thread_lifo() {
+    let target = Arc::new(Mutex::new(None));
+    let latencies = Arc::new(Mutex::new(Vec::new()));
+
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(1)
+        .track_task_schedule_latency()
+        .on_before_task_poll(schedule_latency_hook(&target, &latencies))
+        .build()
+        .unwrap();
+
+    let target2 = Arc::clone(&target);
+    let parent = runtime.spawn(async move {
+        let task = tokio::spawn(async {});
+        *target2.lock().unwrap() = Some(task.id());
+        wait_for_elapsed(Duration::from_millis(50));
+        task.await.unwrap();
+    });
+    runtime.block_on(parent).unwrap();
+
+    let latencies = latencies.lock().unwrap();
+    assert_eq!(latencies.len(), 1);
+    assert!(latencies[0] >= Duration::from_millis(25));
+}
+
+#[cfg(feature = "schedule-latency")]
+fn wait_for_elapsed(duration: Duration) {
+    let start = Instant::now();
+    loop {
+        let elapsed = start.elapsed();
+        if elapsed >= duration {
+            return;
+        }
+        std::thread::sleep(duration - elapsed);
+    }
+}
+
+#[cfg(feature = "schedule-latency")]
+fn schedule_latency_hook(
+    target: &Arc<Mutex<Option<tokio::task::Id>>>,
+    latencies: &Arc<Mutex<Vec<Duration>>>,
+) -> impl Fn(&tokio::runtime::TaskMeta<'_>) {
+    let target = Arc::clone(target);
+    let latencies = Arc::clone(latencies);
+    move |data| {
+        if Some(data.id()) == *target.lock().unwrap() {
+            latencies
+                .lock()
+                .unwrap()
+                .push(data.schedule_latency().unwrap());
+        }
+    }
 }
 
 fn mk_spawn_location_hook(

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -442,7 +442,6 @@ mod spawn_local {
         set.spawn_local(async {});
     }
 
-    #[cfg(tokio_unstable)]
     mod local_runtime {
         use super::*;
 
@@ -556,7 +555,6 @@ mod spawn_local {
 mod spawn_local_on {
     use super::*;
 
-    #[cfg(tokio_unstable)]
     mod local_runtime {
         use super::*;
 

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -138,7 +138,7 @@ fn trace_leaf_for_test(meta: &TraceMeta, log: &mut Vec<Vec<String>>) {
     for frame in bt.frames() {
         for symbol in frame.symbols() {
             if let Some(name) = symbol.name() {
-                names.push(strip_symbol_hash(&format!("{name}")).to_owned());
+                names.push(strip_symbol_hash(&format!("{name:#}")).to_owned());
             }
         }
     }

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -42,10 +42,6 @@ async fn set_linger() {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn try_read_write() {
     const DATA: &[u8] = &[2u8; 4000];
 
@@ -395,10 +391,6 @@ async fn try_read_buf() {
 
 // read_closed is a best effort event, so test only for no false positives.
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/732"
-)]
 async fn read_closed() {
     let (client, mut server) = create_pair().await;
 

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -307,10 +307,6 @@ fn write_until_pending(stream: &mut TcpStream) -> usize {
     total
 }
 
-// This test is temporarily disabled on WASI due to
-// https://github.com/bytecodealliance/wasmtime/issues/13040.  We can re-enable
-// it once that issue is fixed and the fix is included in a Wasmtime release.
-#[cfg_attr(target_os = "wasi", ignore)]
 #[tokio::test]
 async fn try_read_buf() {
     const DATA: &[u8] = &[2u8; 4000];

--- a/tokio/tests/time_rt.rs
+++ b/tokio/tests/time_rt.rs
@@ -1,10 +1,8 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-use futures_test::task::noop_context;
 use tokio::runtime::Runtime;
 use tokio::time::*;
-use tokio_test::assert_pending;
 
 use std::sync::mpsc;
 
@@ -168,9 +166,14 @@ fn timeout_value() {
 }
 
 #[test]
+#[cfg(feature = "test-util")]
 fn tickspace() {
+    use futures::task::noop_waker_ref;
     use std::future::Future as _;
+    use std::task::Context;
     use std::thread;
+    use tokio_test::assert_pending;
+
     let rt = || {
         tokio::runtime::Builder::new_current_thread()
             .enable_time()
@@ -185,7 +188,9 @@ fn tickspace() {
 
     let _guard = rt_past.enter();
     let mut sleep = std::pin::pin!(sleep(Duration::from_millis(1)));
-    assert_pending!(sleep.as_mut().poll(&mut noop_context()));
+    assert_pending!(sleep
+        .as_mut()
+        .poll(&mut Context::from_waker(noop_waker_ref())));
 
     let deadline = sleep.deadline();
     rt.block_on(async { sleep.as_mut().reset(deadline + Duration::from_millis(1)) });

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -58,7 +58,7 @@ async fn send_recv_poll() -> std::io::Result<()> {
 #[tokio::test]
 #[cfg_attr(
     target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
+    ignore = "temporarily disabled for WASI pending https://github.com/bytecodealliance/wasmtime/pull/13933"
 )]
 async fn send_to_recv_closed_returns_err() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
@@ -87,10 +87,6 @@ async fn send_to_recv_closed_returns_err() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn send_to_recv_from() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
     let receiver = UdpSocket::bind("127.0.0.1:0").await?;
@@ -107,10 +103,6 @@ async fn send_to_recv_from() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn send_to_recv_from_poll() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
     let receiver = UdpSocket::bind("127.0.0.1:0").await?;
@@ -497,10 +489,6 @@ async fn try_send_recv() {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn try_send_to_recv_from() {
     // Create listener
     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -605,10 +593,6 @@ async fn recv_buf() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn try_recv_buf_from() {
     // Create listener
     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -652,10 +636,6 @@ async fn try_recv_buf_from() {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn recv_buf_from() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
     let receiver = UdpSocket::bind("127.0.0.1:0").await?;
@@ -673,10 +653,6 @@ async fn recv_buf_from() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn poll_ready() {
     // Create listener
     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
## Motivation

tokio-rs/tokio#7986 added task schedule-latency tracking at a histogram rollup level. This exposes it via `TaskMeta` making it possible for tools like dial9 to quantify the latency of individual polls.

